### PR TITLE
JsonNumber implementation and tests

### DIFF
--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -296,7 +296,6 @@ namespace System.Text.Json
         [System.CLSCompliantAttribute(false)]
         public sbyte GetSByte() { throw null; }
         public float GetSingle() { throw null; }
-        public string GetString() { throw null; }
         [System.CLSCompliantAttribute(false)]
         public ushort GetUInt16() { throw null; }
         [System.CLSCompliantAttribute(false)]
@@ -321,19 +320,20 @@ namespace System.Text.Json
         public static bool operator !=(System.Text.Json.JsonNumber left, System.Text.Json.JsonNumber right) { throw null; }
         public void SetByte(byte value) { }
         public void SetDouble(double value) { }
+        public void SetFormattedValue(string value) { }
         public void SetInt16(short value) { }
         public void SetInt32(int value) { }
         public void SetInt64(long value) { }
         [System.CLSCompliantAttribute(false)]
         public void SetSByte(sbyte value) { }
         public void SetSingle(float value) { }
-        public void SetString(string value) { }
         [System.CLSCompliantAttribute(false)]
         public void SetUInt16(ushort value) { }
         [System.CLSCompliantAttribute(false)]
         public void SetUInt32(uint value) { }
         [System.CLSCompliantAttribute(false)]
         public void SetUInt64(ulong value) { }
+        public override string ToString() { throw null; }
         public bool TryGetByte(out byte value) { throw null; }
         public bool TryGetDouble(out double value) { throw null; }
         public bool TryGetInt16(out short value) { throw null; }

--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -90,14 +90,17 @@ namespace System.Text.Json
         void System.Collections.Generic.ICollection<System.Text.Json.JsonNode>.CopyTo(System.Text.Json.JsonNode[] array, int arrayIndex) { }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
     }
-    public partial class JsonBoolean : System.Text.Json.JsonNode
+    public partial class JsonBoolean : System.Text.Json.JsonNode, System.IEquatable<System.Text.Json.JsonBoolean>
     {
         public JsonBoolean() { }
         public JsonBoolean(bool value) { }
         public bool Value { get { throw null; } set { } }
         public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Text.Json.JsonBoolean other) { throw null; }
         public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Text.Json.JsonBoolean left, System.Text.Json.JsonBoolean right) { throw null; }
         public static implicit operator System.Text.Json.JsonBoolean (bool value) { throw null; }
+        public static bool operator !=(System.Text.Json.JsonBoolean left, System.Text.Json.JsonBoolean right) { throw null; }
     }
     public enum JsonCommentHandling : byte
     {
@@ -264,7 +267,7 @@ namespace System.Text.Json
         public static System.Text.Json.JsonNode Parse(string json) { throw null; }
         public static bool TryGetNode(System.Text.Json.JsonElement jsonElement, out System.Text.Json.JsonNode jsonNode) { throw null; }
     }
-    public partial class JsonNumber : System.Text.Json.JsonNode
+    public partial class JsonNumber : System.Text.Json.JsonNode, System.IEquatable<System.Text.Json.JsonNumber>
     {
         public JsonNumber() { }
         public JsonNumber(byte value) { }
@@ -283,6 +286,7 @@ namespace System.Text.Json
         [System.CLSCompliantAttribute(false)]
         public JsonNumber(ulong value) { }
         public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Text.Json.JsonNumber other) { throw null; }
         public byte GetByte() { throw null; }
         public double GetDouble() { throw null; }
         public override int GetHashCode() { throw null; }
@@ -299,6 +303,7 @@ namespace System.Text.Json
         public uint GetUInt32() { throw null; }
         [System.CLSCompliantAttribute(false)]
         public ulong GetUInt64() { throw null; }
+        public static bool operator ==(System.Text.Json.JsonNumber left, System.Text.Json.JsonNumber right) { throw null; }
         public static implicit operator System.Text.Json.JsonNumber (byte value) { throw null; }
         public static implicit operator System.Text.Json.JsonNumber (double value) { throw null; }
         public static implicit operator System.Text.Json.JsonNumber (short value) { throw null; }
@@ -313,6 +318,7 @@ namespace System.Text.Json
         public static implicit operator System.Text.Json.JsonNumber (uint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static implicit operator System.Text.Json.JsonNumber (ulong value) { throw null; }
+        public static bool operator !=(System.Text.Json.JsonNumber left, System.Text.Json.JsonNumber right) { throw null; }
         public void SetByte(byte value) { }
         public void SetDouble(double value) { }
         public void SetInt16(short value) { }
@@ -445,14 +451,17 @@ namespace System.Text.Json
         public bool WriteIndented { get { throw null; } set { } }
         public System.Text.Json.Serialization.JsonConverter GetConverter(System.Type typeToConvert) { throw null; }
     }
-    public partial class JsonString : System.Text.Json.JsonNode
+    public partial class JsonString : System.Text.Json.JsonNode, System.IEquatable<System.Text.Json.JsonString>
     {
         public JsonString() { }
         public JsonString(string value) { }
         public string Value { get { throw null; } set { } }
         public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Text.Json.JsonString other) { throw null; }
         public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Text.Json.JsonString left, System.Text.Json.JsonString right) { throw null; }
         public static implicit operator System.Text.Json.JsonString (string value) { throw null; }
+        public static bool operator !=(System.Text.Json.JsonString left, System.Text.Json.JsonString right) { throw null; }
     }
     public enum JsonTokenType : byte
     {

--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -271,6 +271,7 @@ namespace System.Text.Json
     {
         public JsonNumber() { }
         public JsonNumber(byte value) { }
+        public JsonNumber(decimal value) { }
         public JsonNumber(double value) { }
         public JsonNumber(short value) { }
         public JsonNumber(int value) { }
@@ -288,6 +289,7 @@ namespace System.Text.Json
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.Text.Json.JsonNumber other) { throw null; }
         public byte GetByte() { throw null; }
+        public decimal GetDecimal() { throw null; }
         public double GetDouble() { throw null; }
         public override int GetHashCode() { throw null; }
         public short GetInt16() { throw null; }
@@ -304,6 +306,7 @@ namespace System.Text.Json
         public ulong GetUInt64() { throw null; }
         public static bool operator ==(System.Text.Json.JsonNumber left, System.Text.Json.JsonNumber right) { throw null; }
         public static implicit operator System.Text.Json.JsonNumber (byte value) { throw null; }
+        public static implicit operator System.Text.Json.JsonNumber (decimal value) { throw null; }
         public static implicit operator System.Text.Json.JsonNumber (double value) { throw null; }
         public static implicit operator System.Text.Json.JsonNumber (short value) { throw null; }
         public static implicit operator System.Text.Json.JsonNumber (int value) { throw null; }
@@ -319,6 +322,7 @@ namespace System.Text.Json
         public static implicit operator System.Text.Json.JsonNumber (ulong value) { throw null; }
         public static bool operator !=(System.Text.Json.JsonNumber left, System.Text.Json.JsonNumber right) { throw null; }
         public void SetByte(byte value) { }
+        public void SetDecimal(decimal value) { }
         public void SetDouble(double value) { }
         public void SetFormattedValue(string value) { }
         public void SetInt16(short value) { }
@@ -335,6 +339,7 @@ namespace System.Text.Json
         public void SetUInt64(ulong value) { }
         public override string ToString() { throw null; }
         public bool TryGetByte(out byte value) { throw null; }
+        public bool TryGetDecimal(out decimal value) { throw null; }
         public bool TryGetDouble(out double value) { throw null; }
         public bool TryGetInt16(out short value) { throw null; }
         public bool TryGetInt32(out int value) { throw null; }

--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -12,6 +12,7 @@ namespace System.Text.Json
         public JsonArray() { }
         public JsonArray(System.Collections.Generic.IEnumerable<bool> values) { }
         public JsonArray(System.Collections.Generic.IEnumerable<byte> values) { }
+        public JsonArray(System.Collections.Generic.IEnumerable<decimal> values) { }
         public JsonArray(System.Collections.Generic.IEnumerable<double> values) { }
         public JsonArray(System.Collections.Generic.IEnumerable<short> values) { }
         public JsonArray(System.Collections.Generic.IEnumerable<int> values) { }
@@ -32,6 +33,7 @@ namespace System.Text.Json
         public System.Text.Json.JsonNode this[int idx] { get { throw null; } set { } }
         public void Add(bool value) { }
         public void Add(byte value) { }
+        public void Add(decimal value) { }
         public void Add(double value) { }
         public void Add(short value) { }
         public void Add(int value) { }
@@ -50,6 +52,7 @@ namespace System.Text.Json
         public void Clear() { }
         public bool Contains(bool value) { throw null; }
         public bool Contains(byte value) { throw null; }
+        public bool Contains(decimal value) { throw null; }
         public bool Contains(double value) { throw null; }
         public bool Contains(short value) { throw null; }
         public bool Contains(int value) { throw null; }
@@ -69,6 +72,7 @@ namespace System.Text.Json
         public int IndexOf(System.Text.Json.JsonNode item) { throw null; }
         public void Insert(int index, bool item) { }
         public void Insert(int index, byte item) { }
+        public void Insert(int index, decimal item) { }
         public void Insert(int index, double item) { }
         public void Insert(int index, short item) { }
         public void Insert(int index, int item) { }
@@ -365,6 +369,7 @@ namespace System.Text.Json
         public void Add(string propertyName, bool propertyValue) { }
         public void Add(string propertyName, byte propertyValue) { }
         public void Add(string propertyName, System.Collections.Generic.IEnumerable<System.Text.Json.JsonNode> propertyValue) { }
+        public void Add(string propertyName, decimal propertyValue) { }
         public void Add(string propertyName, double propertyValue) { }
         public void Add(string propertyName, short propertyValue) { }
         public void Add(string propertyName, int propertyValue) { }

--- a/src/System.Text.Json/src/System/Text/Json/Node/JsonArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Node/JsonArray.cs
@@ -30,6 +30,7 @@ namespace System.Text.Json
         public JsonArray(IEnumerable<uint> values) { }
         [CLSCompliant(false)]
         public JsonArray(IEnumerable<ulong> values) { }
+        public JsonArray(IEnumerable<decimal> values) { }
 
         public JsonNode this[int idx] { get => throw null; set => throw null; }
 
@@ -50,6 +51,7 @@ namespace System.Text.Json
         public void Add(uint value) { }
         [CLSCompliant(false)]
         public void Add(ulong value) { }
+        public void Add(decimal value) { }
 
         public void Insert(int index, JsonNode item) { throw null; }
         public void Insert(int index, string item) { throw null; }
@@ -68,6 +70,7 @@ namespace System.Text.Json
         public void Insert(int index, uint item) { throw null; }
         [CLSCompliant(false)]
         public void Insert(int index, ulong item) { throw null; }
+        public void Insert(int index, decimal item) { throw null; }
 
         public bool Contains(JsonNode value) { throw null; }
         public bool Contains(string value) { throw null; }
@@ -86,6 +89,7 @@ namespace System.Text.Json
         public bool Contains(uint value) { throw null; }
         [CLSCompliant(false)]
         public bool Contains(ulong value) { throw null; }
+        public bool Contains(decimal value) { throw null; }
 
         public int Count => throw null;
         public bool IsReadOnly => throw null;

--- a/src/System.Text.Json/src/System/Text/Json/Node/JsonBoolean.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Node/JsonBoolean.cs
@@ -7,7 +7,7 @@
 
 namespace System.Text.Json
 {
-    public partial class JsonBoolean : JsonNode
+    public partial class JsonBoolean : JsonNode, IEquatable<JsonBoolean>
     {
         public JsonBoolean() { }
         public JsonBoolean(bool value) { }
@@ -18,7 +18,11 @@ namespace System.Text.Json
 
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
+
+        public bool Equals(JsonBoolean other) { throw null; }
+
+        public static bool operator ==(JsonBoolean left, JsonBoolean right) => throw null;
+        public static bool operator !=(JsonBoolean left, JsonBoolean right) => throw null;
     }
 }
-
 #pragma warning restore CS1591

--- a/src/System.Text.Json/src/System/Text/Json/Node/JsonNumber.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Node/JsonNumber.cs
@@ -9,10 +9,7 @@ namespace System.Text.Json
 {
     public partial class JsonNumber : JsonNode, IEquatable<JsonNumber>
     {
-        // number representation stored:
-        // * in big-endian if created from number
-        // * in Utf8 if created from string
-        private byte[] _bytes;
+        private string _value;
 
         public JsonNumber() { }
         public JsonNumber(string value)
@@ -31,7 +28,6 @@ namespace System.Text.Json
         {
             SetInt32(value);
         }
-
         public JsonNumber(long value)
         {
             SetInt64(value);
@@ -65,102 +61,237 @@ namespace System.Text.Json
             SetUInt64(value);
         }
 
-        private void AdjustBitOrder()
+        public string GetString()
+        { 
+            return _value; 
+        }
+        public byte GetByte()
         {
-            if (BitConverter.IsLittleEndian)
-                Array.Reverse(_bytes);
+            return byte.Parse(_value);
+        }
+        public short GetInt16()
+        {
+            return short.Parse(_value);
+        }
+        public int GetInt32()
+        {
+            return int.Parse(_value);
+        }
+        public long GetInt64()
+        {
+            return long.Parse(_value);
+        }
+        public float GetSingle()
+        {
+            return float.Parse(_value);
+        }
+        public double GetDouble()
+        {
+            return double.Parse(_value);
+        }
+        [CLSCompliant(false)]
+        public sbyte GetSByte()
+        {
+            return sbyte.Parse(_value);
+        }
+        [CLSCompliant(false)]
+        public ushort GetUInt16()
+        {
+            return ushort.Parse(_value);
+        }
+        [CLSCompliant(false)]
+        public uint GetUInt32()
+        {
+            return uint.Parse(_value);
+        }
+        [CLSCompliant(false)]
+        public ulong GetUInt64()
+        {
+            return ulong.Parse(_value);
         }
 
-        public string GetString() { throw null; }
-        public byte GetByte() { throw null; }
-        public int GetInt32() { throw null; }
-        public short GetInt16() { throw null; }
-        public long GetInt64() { throw null; }
-        public float GetSingle() { throw null; }
-        public double GetDouble() { throw null; }
+        public bool TryGetByte(out byte value)
+        {
+            try
+            {
+                value = GetByte();
+                return true;
+            } 
+           catch(Exception)
+            {
+                value = 0;
+                return false;
+            }
+        }
+        public bool TryGetInt16(out short value)
+        {
+            try
+            {
+                value = GetInt16();
+                return true;
+            }
+            catch (Exception)
+            {
+                value = 0;
+                return false;
+            }
+        }
+        public bool TryGetInt32(out int value)
+        {
+            try
+            {
+                value = GetInt32();
+                return true;
+            }
+            catch (Exception)
+            {
+                value = 0;
+                return false;
+            }
+        }
+        public bool TryGetInt64(out long value)
+        {
+            try
+            {
+                value = GetInt64();
+                return true;
+            }
+            catch (Exception)
+            {
+                value = 0;
+                return false;
+            }
+        }
+        public bool TryGetSingle(out float value)
+        {
+            try
+            {
+                value = GetSingle();
+                return true;
+            }
+            catch (Exception)
+            {
+                value = 0;
+                return false;
+            }
+        }
+        public bool TryGetDouble(out double value)
+        {
+            try
+            {
+                value = GetDouble();
+                return true;
+            }
+            catch (Exception)
+            {
+                value = 0;
+                return false;
+            }
+        }
         [CLSCompliant(false)]
-        public sbyte GetSByte() { throw null; }
+        public bool TryGetSByte(out sbyte value)
+        {
+            try
+            {
+                value = GetSByte();
+                return true;
+            }
+            catch (Exception)
+            {
+                value = 0;
+                return false;
+            }
+        }
         [CLSCompliant(false)]
-        public ushort GetUInt16() { throw null; }
+        public bool TryGetUInt16(out ushort value)
+        {
+            try
+            {
+                value = GetUInt16();
+                return true;
+            }
+            catch (Exception)
+            {
+                value = 0;
+                return false;
+            }
+        }
         [CLSCompliant(false)]
-        public uint GetUInt32() { throw null; }
+        public bool TryGetUInt32(out uint value)
+        {
+            try
+            {
+                value = GetUInt32();
+                return true;
+            }
+            catch (Exception)
+            {
+                value = 0;
+                return false;
+            }
+        }
         [CLSCompliant(false)]
-        public ulong GetUInt64() { throw null; }
-
-        public bool TryGetByte(out byte value) { throw null; }
-        public bool TryGetInt32(out int value) { throw null; }
-        public bool TryGetInt16(out short value) { throw null; }
-        public bool TryGetInt64(out long value) { throw null; }
-        public bool TryGetSingle(out float value) { throw null; }
-        public bool TryGetDouble(out double value) { throw null; }
-        [CLSCompliant(false)]
-        public bool TryGetSByte(out sbyte value) { throw null; }
-        [CLSCompliant(false)]
-        public bool TryGetUInt16(out ushort value) { throw null; }
-        [CLSCompliant(false)]
-        public bool TryGetUInt32(out uint value) { throw null; }
-        [CLSCompliant(false)]
-        public bool TryGetUInt64(out ulong value) { throw null; }
+        public bool TryGetUInt64(out ulong value)
+        {
+            try
+            {
+                value = GetUInt64();
+                return true;
+            }
+            catch (Exception)
+            {
+                value = 0;
+                return false;
+            }
+        }
 
         public void SetString(string value)
         {
-            _bytes = Encoding.UTF8.GetBytes(value);
+            _value = value;
         }
         public void SetByte(byte value)
         {
-            _bytes = new byte[1];
-            _bytes[0] = value;
-            AdjustBitOrder();
-        }
-        public void SetInt32(int value)
-        {
-            _bytes = BitConverter.GetBytes(value);
-            AdjustBitOrder();
+            _value = value.ToString();
         }
         public void SetInt16(short value)
         {
-            _bytes = BitConverter.GetBytes(value);
-            AdjustBitOrder();
+            _value = value.ToString();
+        }
+        public void SetInt32(int value)
+        {
+            _value = value.ToString();
         }
         public void SetInt64(long value)
         {
-            _bytes = BitConverter.GetBytes(value);
-            AdjustBitOrder();
+            _value = value.ToString();
         }
         public void SetSingle(float value)
         {
-            _bytes = BitConverter.GetBytes(value);
-            AdjustBitOrder();
+            _value = value.ToString();
         }
         public void SetDouble(double value)
         {
-            _bytes = BitConverter.GetBytes(value);
-            AdjustBitOrder();
+            _value = value.ToString();
         }
         [CLSCompliant(false)]
         public void SetSByte(sbyte value)
         {
-            _bytes = new byte[1];
-            _bytes[0] = (byte)value;
-            AdjustBitOrder();
+            _value = value.ToString();
         }
         [CLSCompliant(false)]
         public void SetUInt16(ushort value)
         {
-            _bytes = BitConverter.GetBytes(value);
-            AdjustBitOrder();
+            _value = value.ToString();
         }
         [CLSCompliant(false)]
         public void SetUInt32(uint value)
         {
-            _bytes = BitConverter.GetBytes(value);
-            AdjustBitOrder();
+            _value = value.ToString();
         }
         [CLSCompliant(false)]
         public void SetUInt64(ulong value)
         {
-            _bytes = BitConverter.GetBytes(value);
-            AdjustBitOrder();
+            _value = value.ToString();
         }
 
         public static implicit operator JsonNumber(byte value)

--- a/src/System.Text.Json/src/System/Text/Json/Node/JsonNumber.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Node/JsonNumber.cs
@@ -163,20 +163,50 @@ namespace System.Text.Json
             AdjustBitOrder();
         }
 
-        public static implicit operator JsonNumber(byte value) { throw null; }
-        public static implicit operator JsonNumber(int value) { throw null; }
-        public static implicit operator JsonNumber(short value) { throw null; }
-        public static implicit operator JsonNumber(long value) { throw null; }
-        public static implicit operator JsonNumber(float value) { throw null; }
-        public static implicit operator JsonNumber(double value) { throw null; }
+        public static implicit operator JsonNumber(byte value)
+        {
+            return new JsonNumber(value);
+        }
+        public static implicit operator JsonNumber(int value)
+        {
+            return new JsonNumber(value);
+        }
+        public static implicit operator JsonNumber(short value)
+        {
+            return new JsonNumber(value);
+        }
+        public static implicit operator JsonNumber(long value)
+        {
+            return new JsonNumber(value);
+        }
+        public static implicit operator JsonNumber(float value)
+        {
+            return new JsonNumber(value);
+        }
+        public static implicit operator JsonNumber(double value)
+        {
+            return new JsonNumber(value);
+        }
         [CLSCompliant(false)]
-        public static implicit operator JsonNumber(sbyte value) { throw null; }
+        public static implicit operator JsonNumber(sbyte value)
+        {
+            return new JsonNumber(value);
+        }
         [CLSCompliant(false)]
-        public static implicit operator JsonNumber(ushort value) { throw null; }
+        public static implicit operator JsonNumber(ushort value)
+        {
+            return new JsonNumber(value);
+        }
         [CLSCompliant(false)]
-        public static implicit operator JsonNumber(uint value) { throw null; }
+        public static implicit operator JsonNumber(uint value)
+        {
+            return new JsonNumber(value);
+        }
         [CLSCompliant(false)]
-        public static implicit operator JsonNumber(ulong value) { throw null; }
+        public static implicit operator JsonNumber(ulong value)
+        {
+            return new JsonNumber(value);
+        }
 
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }

--- a/src/System.Text.Json/src/System/Text/Json/Node/JsonNumber.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Node/JsonNumber.cs
@@ -95,9 +95,9 @@ namespace System.Text.Json
         public void SetFormattedValue(string value)
         {
             if (value == null)
-                throw new NullReferenceException("Expected number, but instead got null.");
-            if (value == "")
-                throw new ArgumentException("Expected number, but instead got empty string.");
+                throw new ArgumentNullException(nameof(value));
+            if (value.Length == 0)
+                throw new ArgumentException("Expected number, but instead got empty string.", nameof(value));
             
             JsonWriterHelper.ValidateNumber(Encoding.UTF8.GetBytes(value).AsSpan());
             _value = value;

--- a/src/System.Text.Json/src/System/Text/Json/Node/JsonNumber.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Node/JsonNumber.cs
@@ -5,6 +5,8 @@
 // for now disabling error caused by not adding documentation to methods 
 #pragma warning disable CS1591
 
+using System.Buffers;
+
 namespace System.Text.Json
 {
     public partial class JsonNumber : JsonNode, IEquatable<JsonNumber>
@@ -13,7 +15,7 @@ namespace System.Text.Json
 
         public JsonNumber() => _value = "0";
 
-        public JsonNumber(string value) => SetString(value);
+        public JsonNumber(string value) => SetFormattedValue(value);
         
         public JsonNumber(byte value) => SetByte(value);
         
@@ -39,7 +41,7 @@ namespace System.Text.Json
         [CLSCompliant(false)]
         public JsonNumber(ulong value) => SetUInt64(value);
 
-        public string GetString() => _value; 
+        public override string ToString() => _value; 
         
         public byte GetByte() => byte.Parse(_value);
         
@@ -90,8 +92,13 @@ namespace System.Text.Json
         public bool TryGetUInt64(out ulong value) => ulong.TryParse(_value, out value);
 
 
-        public void SetString(string value)
+        public void SetFormattedValue(string value)
         {
+            if (value == null)
+                throw new NullReferenceException("Expected number, but instead got null.");
+            if (value == "")
+                throw new ArgumentException("Expected number, but instead got empty string.");
+            
             JsonWriterHelper.ValidateNumber(Encoding.UTF8.GetBytes(value).AsSpan());
             _value = value;
         }
@@ -146,7 +153,7 @@ namespace System.Text.Json
 
         public override bool Equals(object obj) => obj is JsonNumber number && _value == number._value;
 
-        public override int GetHashCode() => HashCode.Combine(_value);
+        public override int GetHashCode() => _value.GetHashCode();
 
         public bool Equals(JsonNumber other) => _value == other._value;
 

--- a/src/System.Text.Json/src/System/Text/Json/Node/JsonNumber.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Node/JsonNumber.cs
@@ -41,6 +41,8 @@ namespace System.Text.Json
         [CLSCompliant(false)]
         public JsonNumber(ulong value) => SetUInt64(value);
 
+        public JsonNumber(decimal value) => SetDecimal(value);
+
         public override string ToString() => _value; 
         
         public byte GetByte() => byte.Parse(_value);
@@ -67,6 +69,8 @@ namespace System.Text.Json
         [CLSCompliant(false)]
         public ulong GetUInt64() => ulong.Parse(_value);
 
+        public decimal GetDecimal() => decimal.Parse(_value);
+
         public bool TryGetByte(out byte value) => byte.TryParse(_value, out value);
 
         public bool TryGetInt16(out short value) => short.TryParse(_value, out value);
@@ -90,6 +94,8 @@ namespace System.Text.Json
 
         [CLSCompliant(false)]
         public bool TryGetUInt64(out ulong value) => ulong.TryParse(_value, out value);
+
+        public bool TryGetDecimal(out decimal value) => decimal.TryParse(_value, out value);
 
 
         public void SetFormattedValue(string value)
@@ -127,6 +133,8 @@ namespace System.Text.Json
         [CLSCompliant(false)]
         public void SetUInt64(ulong value) => _value = value.ToString();
 
+        public void SetDecimal(decimal value) => _value = value.ToString();
+
         public static implicit operator JsonNumber(byte value) => new JsonNumber(value);
         
         public static implicit operator JsonNumber(int value) => new JsonNumber(value);
@@ -150,6 +158,8 @@ namespace System.Text.Json
         
         [CLSCompliant(false)]
         public static implicit operator JsonNumber(ulong value) => new JsonNumber(value);
+
+        public static implicit operator JsonNumber(decimal value) => new JsonNumber(value);
 
         public override bool Equals(object obj) => obj is JsonNumber number && _value == number._value;
 

--- a/src/System.Text.Json/src/System/Text/Json/Node/JsonNumber.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Node/JsonNumber.cs
@@ -117,7 +117,7 @@ namespace System.Text.Json
                 value = GetByte();
                 return true;
             } 
-           catch(Exception)
+           catch
             {
                 value = 0;
                 return false;
@@ -130,7 +130,7 @@ namespace System.Text.Json
                 value = GetInt16();
                 return true;
             }
-            catch (Exception)
+            catch
             {
                 value = 0;
                 return false;
@@ -143,7 +143,7 @@ namespace System.Text.Json
                 value = GetInt32();
                 return true;
             }
-            catch (Exception)
+            catch
             {
                 value = 0;
                 return false;
@@ -156,7 +156,7 @@ namespace System.Text.Json
                 value = GetInt64();
                 return true;
             }
-            catch (Exception)
+            catch
             {
                 value = 0;
                 return false;
@@ -169,7 +169,7 @@ namespace System.Text.Json
                 value = GetSingle();
                 return true;
             }
-            catch (Exception)
+            catch
             {
                 value = 0;
                 return false;
@@ -182,7 +182,7 @@ namespace System.Text.Json
                 value = GetDouble();
                 return true;
             }
-            catch (Exception)
+            catch
             {
                 value = 0;
                 return false;
@@ -196,7 +196,7 @@ namespace System.Text.Json
                 value = GetSByte();
                 return true;
             }
-            catch (Exception)
+            catch
             {
                 value = 0;
                 return false;
@@ -210,7 +210,7 @@ namespace System.Text.Json
                 value = GetUInt16();
                 return true;
             }
-            catch (Exception)
+            catch
             {
                 value = 0;
                 return false;
@@ -224,7 +224,7 @@ namespace System.Text.Json
                 value = GetUInt32();
                 return true;
             }
-            catch (Exception)
+            catch
             {
                 value = 0;
                 return false;
@@ -238,7 +238,7 @@ namespace System.Text.Json
                 value = GetUInt64();
                 return true;
             }
-            catch (Exception)
+            catch
             {
                 value = 0;
                 return false;
@@ -247,8 +247,10 @@ namespace System.Text.Json
 
         public void SetString(string value)
         {
+            JsonWriterHelper.ValidateNumber(Encoding.UTF8.GetBytes(value).AsSpan());
             _value = value;
         }
+
         public void SetByte(byte value)
         {
             _value = value.ToString();

--- a/src/System.Text.Json/src/System/Text/Json/Node/JsonNumber.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Node/JsonNumber.cs
@@ -7,7 +7,7 @@
 
 namespace System.Text.Json
 {
-    public partial class JsonNumber : JsonNode
+    public partial class JsonNumber : JsonNode, IEquatable<JsonNumber>
     {
         public JsonNumber() { }
         public JsonNumber(string value) { }
@@ -90,6 +90,11 @@ namespace System.Text.Json
 
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
+
+        public bool Equals(JsonNumber other) { throw null; }
+
+        public static bool operator ==(JsonNumber left, JsonNumber right) => throw null;
+        public static bool operator !=(JsonNumber left, JsonNumber right) => throw null;
     }
 }
 

--- a/src/System.Text.Json/src/System/Text/Json/Node/JsonNumber.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Node/JsonNumber.cs
@@ -339,13 +339,23 @@ namespace System.Text.Json
             return new JsonNumber(value);
         }
 
-        public override bool Equals(object obj) { throw null; }
-        public override int GetHashCode() { throw null; }
+        public override bool Equals(object obj)
+        {
+            return obj is JsonNumber number &&
+                   _value == number._value;
+        }
 
-        public bool Equals(JsonNumber other) { throw null; }
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(_value);
+        }
+        public bool Equals(JsonNumber other)
+        {
+            return _value == other._value;
+        }
 
-        public static bool operator ==(JsonNumber left, JsonNumber right) => throw null;
-        public static bool operator !=(JsonNumber left, JsonNumber right) => throw null;
+        public static bool operator ==(JsonNumber left, JsonNumber right) => left._value == right._value;
+        public static bool operator !=(JsonNumber left, JsonNumber right) => left._value != right._value;
     }
 }
 

--- a/src/System.Text.Json/src/System/Text/Json/Node/JsonNumber.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Node/JsonNumber.cs
@@ -11,239 +11,84 @@ namespace System.Text.Json
     {
         private string _value;
 
-        public JsonNumber() { }
-        public JsonNumber(string value)
-        {
-            SetString(value);
-        }
-        public JsonNumber(byte value)
-        {
-            SetByte(value);
-        }
-        public JsonNumber(short value)
-        {
-            SetInt16(value);
-        }
-        public JsonNumber(int value)
-        {
-            SetInt32(value);
-        }
-        public JsonNumber(long value)
-        {
-            SetInt64(value);
-        }
-        public JsonNumber(float value)
-        {
-            SetSingle(value);
-        }
-        public JsonNumber(double value)
-        {
-            SetDouble(value);
-        }
-        [CLSCompliant(false)]
-        public JsonNumber(sbyte value)
-        {
-            SetSByte(value);
-        }
-        [CLSCompliant(false)]
-        public JsonNumber(ushort value)
-        {
-            SetUInt16(value);
-        }
-        [CLSCompliant(false)]
-        public JsonNumber(uint value)
-        {
-            SetUInt32(value);
-        }
-        [CLSCompliant(false)]
-        public JsonNumber(ulong value)
-        {
-            SetUInt64(value);
-        }
+        public JsonNumber() => _value = "0";
 
-        public string GetString()
-        { 
-            return _value; 
-        }
-        public byte GetByte()
-        {
-            return byte.Parse(_value);
-        }
-        public short GetInt16()
-        {
-            return short.Parse(_value);
-        }
-        public int GetInt32()
-        {
-            return int.Parse(_value);
-        }
-        public long GetInt64()
-        {
-            return long.Parse(_value);
-        }
-        public float GetSingle()
-        {
-            return float.Parse(_value);
-        }
-        public double GetDouble()
-        {
-            return double.Parse(_value);
-        }
+        public JsonNumber(string value) => SetString(value);
+        
+        public JsonNumber(byte value) => SetByte(value);
+        
+        public JsonNumber(short value) => SetInt16(value);
+        
+        public JsonNumber(int value) => SetInt32(value);
+        
+        public JsonNumber(long value) => SetInt64(value);
+        
+        public JsonNumber(float value) => SetSingle(value);
+        
+        public JsonNumber(double value) => SetDouble(value);
+        
         [CLSCompliant(false)]
-        public sbyte GetSByte()
-        {
-            return sbyte.Parse(_value);
-        }
+        public JsonNumber(sbyte value) => SetSByte(value);
+        
         [CLSCompliant(false)]
-        public ushort GetUInt16()
-        {
-            return ushort.Parse(_value);
-        }
+        public JsonNumber(ushort value) => SetUInt16(value);
+        
         [CLSCompliant(false)]
-        public uint GetUInt32()
-        {
-            return uint.Parse(_value);
-        }
+        public JsonNumber(uint value) => SetUInt32(value);
+        
         [CLSCompliant(false)]
-        public ulong GetUInt64()
-        {
-            return ulong.Parse(_value);
-        }
+        public JsonNumber(ulong value) => SetUInt64(value);
 
-        public bool TryGetByte(out byte value)
-        {
-            try
-            {
-                value = GetByte();
-                return true;
-            } 
-           catch
-            {
-                value = 0;
-                return false;
-            }
-        }
-        public bool TryGetInt16(out short value)
-        {
-            try
-            {
-                value = GetInt16();
-                return true;
-            }
-            catch
-            {
-                value = 0;
-                return false;
-            }
-        }
-        public bool TryGetInt32(out int value)
-        {
-            try
-            {
-                value = GetInt32();
-                return true;
-            }
-            catch
-            {
-                value = 0;
-                return false;
-            }
-        }
-        public bool TryGetInt64(out long value)
-        {
-            try
-            {
-                value = GetInt64();
-                return true;
-            }
-            catch
-            {
-                value = 0;
-                return false;
-            }
-        }
-        public bool TryGetSingle(out float value)
-        {
-            try
-            {
-                value = GetSingle();
-                return true;
-            }
-            catch
-            {
-                value = 0;
-                return false;
-            }
-        }
-        public bool TryGetDouble(out double value)
-        {
-            try
-            {
-                value = GetDouble();
-                return true;
-            }
-            catch
-            {
-                value = 0;
-                return false;
-            }
-        }
+        public string GetString() => _value; 
+        
+        public byte GetByte() => byte.Parse(_value);
+        
+        public short GetInt16() => short.Parse(_value);
+        
+        public int GetInt32() => int.Parse(_value);
+        
+        public long GetInt64() => long.Parse(_value);
+        
+        public float GetSingle() => float.Parse(_value);
+        
+        public double GetDouble() => double.Parse(_value);
+        
         [CLSCompliant(false)]
-        public bool TryGetSByte(out sbyte value)
-        {
-            try
-            {
-                value = GetSByte();
-                return true;
-            }
-            catch
-            {
-                value = 0;
-                return false;
-            }
-        }
+        public sbyte GetSByte() => sbyte.Parse(_value);
+        
         [CLSCompliant(false)]
-        public bool TryGetUInt16(out ushort value)
-        {
-            try
-            {
-                value = GetUInt16();
-                return true;
-            }
-            catch
-            {
-                value = 0;
-                return false;
-            }
-        }
+        public ushort GetUInt16() => ushort.Parse(_value);
+        
         [CLSCompliant(false)]
-        public bool TryGetUInt32(out uint value)
-        {
-            try
-            {
-                value = GetUInt32();
-                return true;
-            }
-            catch
-            {
-                value = 0;
-                return false;
-            }
-        }
+        public uint GetUInt32() => uint.Parse(_value);
+        
         [CLSCompliant(false)]
-        public bool TryGetUInt64(out ulong value)
-        {
-            try
-            {
-                value = GetUInt64();
-                return true;
-            }
-            catch
-            {
-                value = 0;
-                return false;
-            }
-        }
+        public ulong GetUInt64() => ulong.Parse(_value);
+
+        public bool TryGetByte(out byte value) => byte.TryParse(_value, out value);
+
+        public bool TryGetInt16(out short value) => short.TryParse(_value, out value);
+
+        public bool TryGetInt32(out int value) => int.TryParse(_value, out value);
+
+        public bool TryGetInt64(out long value) => long.TryParse(_value, out value);
+
+        public bool TryGetSingle(out float value) => float.TryParse(_value, out value);
+
+        public bool TryGetDouble(out double value) => double.TryParse(_value, out value);
+
+        [CLSCompliant(false)]
+        public bool TryGetSByte(out sbyte value) => sbyte.TryParse(_value, out value);
+
+        [CLSCompliant(false)]
+        public bool TryGetUInt16(out ushort value) => ushort.TryParse(_value, out value);
+
+        [CLSCompliant(false)]
+        public bool TryGetUInt32(out uint value) => uint.TryParse(_value, out value);
+
+        [CLSCompliant(false)]
+        public bool TryGetUInt64(out ulong value) => ulong.TryParse(_value, out value);
+
 
         public void SetString(string value)
         {
@@ -251,112 +96,62 @@ namespace System.Text.Json
             _value = value;
         }
 
-        public void SetByte(byte value)
-        {
-            _value = value.ToString();
-        }
-        public void SetInt16(short value)
-        {
-            _value = value.ToString();
-        }
-        public void SetInt32(int value)
-        {
-            _value = value.ToString();
-        }
-        public void SetInt64(long value)
-        {
-            _value = value.ToString();
-        }
-        public void SetSingle(float value)
-        {
-            _value = value.ToString();
-        }
-        public void SetDouble(double value)
-        {
-            _value = value.ToString();
-        }
+        public void SetByte(byte value) => _value = value.ToString();
+        
+        public void SetInt16(short value) => _value = value.ToString();
+        
+        public void SetInt32(int value) => _value = value.ToString();
+        
+        public void SetInt64(long value) => _value = value.ToString();
+        
+        public void SetSingle(float value) => _value = value.ToString();
+        
+        public void SetDouble(double value) => _value = value.ToString();
+        
         [CLSCompliant(false)]
-        public void SetSByte(sbyte value)
-        {
-            _value = value.ToString();
-        }
+        public void SetSByte(sbyte value) => _value = value.ToString();
+        
         [CLSCompliant(false)]
-        public void SetUInt16(ushort value)
-        {
-            _value = value.ToString();
-        }
+        public void SetUInt16(ushort value) => _value = value.ToString();
+        
         [CLSCompliant(false)]
-        public void SetUInt32(uint value)
-        {
-            _value = value.ToString();
-        }
+        public void SetUInt32(uint value) => _value = value.ToString();
+        
         [CLSCompliant(false)]
-        public void SetUInt64(ulong value)
-        {
-            _value = value.ToString();
-        }
+        public void SetUInt64(ulong value) => _value = value.ToString();
 
-        public static implicit operator JsonNumber(byte value)
-        {
-            return new JsonNumber(value);
-        }
-        public static implicit operator JsonNumber(int value)
-        {
-            return new JsonNumber(value);
-        }
-        public static implicit operator JsonNumber(short value)
-        {
-            return new JsonNumber(value);
-        }
-        public static implicit operator JsonNumber(long value)
-        {
-            return new JsonNumber(value);
-        }
-        public static implicit operator JsonNumber(float value)
-        {
-            return new JsonNumber(value);
-        }
-        public static implicit operator JsonNumber(double value)
-        {
-            return new JsonNumber(value);
-        }
+        public static implicit operator JsonNumber(byte value) => new JsonNumber(value);
+        
+        public static implicit operator JsonNumber(int value) => new JsonNumber(value);
+        
+        public static implicit operator JsonNumber(short value) => new JsonNumber(value);
+        
+        public static implicit operator JsonNumber(long value) => new JsonNumber(value);
+        
+        public static implicit operator JsonNumber(float value) => new JsonNumber(value);
+        
+        public static implicit operator JsonNumber(double value) => new JsonNumber(value);
+        
         [CLSCompliant(false)]
-        public static implicit operator JsonNumber(sbyte value)
-        {
-            return new JsonNumber(value);
-        }
+        public static implicit operator JsonNumber(sbyte value) => new JsonNumber(value);
+        
         [CLSCompliant(false)]
-        public static implicit operator JsonNumber(ushort value)
-        {
-            return new JsonNumber(value);
-        }
+        public static implicit operator JsonNumber(ushort value) => new JsonNumber(value);
+        
         [CLSCompliant(false)]
-        public static implicit operator JsonNumber(uint value)
-        {
-            return new JsonNumber(value);
-        }
+        public static implicit operator JsonNumber(uint value) => new JsonNumber(value);
+        
         [CLSCompliant(false)]
-        public static implicit operator JsonNumber(ulong value)
-        {
-            return new JsonNumber(value);
-        }
+        public static implicit operator JsonNumber(ulong value) => new JsonNumber(value);
 
-        public override bool Equals(object obj)
-        {
-            return obj is JsonNumber number &&
-                   _value == number._value;
-        }
+        public override bool Equals(object obj) => obj is JsonNumber number && _value == number._value;
 
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(_value);
-        }
-        public bool Equals(JsonNumber other)
-        {
-            return _value == other._value;
-        }
+        public override int GetHashCode() => HashCode.Combine(_value);
+
+        public bool Equals(JsonNumber other) => _value == other._value;
 
         public static bool operator ==(JsonNumber left, JsonNumber right) => left._value == right._value;
+        
         public static bool operator !=(JsonNumber left, JsonNumber right) => left._value != right._value;
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Node/JsonNumber.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Node/JsonNumber.cs
@@ -17,64 +17,52 @@ namespace System.Text.Json
         public JsonNumber() { }
         public JsonNumber(string value)
         {
-            _bytes = Encoding.UTF8.GetBytes(value);
+            SetString(value);
         }
         public JsonNumber(byte value)
         {
-            _bytes = new byte[1];
-            _bytes[0] = value;
-            AdjustBitOrder();
+            SetByte(value);
         }
         public JsonNumber(short value)
         {
-            _bytes = BitConverter.GetBytes(value);
-            AdjustBitOrder();
+            SetInt16(value);
         }
         public JsonNumber(int value)
         {
-            _bytes = BitConverter.GetBytes(value);
-            AdjustBitOrder();
+            SetInt32(value);
         }
 
         public JsonNumber(long value)
         {
-            _bytes = BitConverter.GetBytes(value);
-            AdjustBitOrder();
+            SetInt64(value);
         }
         public JsonNumber(float value)
         {
-            _bytes = BitConverter.GetBytes(value);
-            AdjustBitOrder();
+            SetSingle(value);
         }
         public JsonNumber(double value)
         {
-            _bytes = BitConverter.GetBytes(value);
-            AdjustBitOrder();
+            SetDouble(value);
         }
         [CLSCompliant(false)]
         public JsonNumber(sbyte value)
         {
-            _bytes = new byte[1];
-            _bytes[0] = (byte) value;
-            AdjustBitOrder();
+            SetSByte(value);
         }
         [CLSCompliant(false)]
         public JsonNumber(ushort value)
         {
-            _bytes = BitConverter.GetBytes(value);
-            AdjustBitOrder();
+            SetUInt16(value);
         }
         [CLSCompliant(false)]
         public JsonNumber(uint value)
         {
-            _bytes = BitConverter.GetBytes(value);
-            AdjustBitOrder();
+            SetUInt32(value);
         }
         [CLSCompliant(false)]
         public JsonNumber(ulong value)
         {
-            _bytes = BitConverter.GetBytes(value);
-            AdjustBitOrder();
+            SetUInt64(value);
         }
 
         private void AdjustBitOrder()
@@ -114,21 +102,66 @@ namespace System.Text.Json
         [CLSCompliant(false)]
         public bool TryGetUInt64(out ulong value) { throw null; }
 
-        public void SetString(string value) { }
-        public void SetByte(byte value) { }
-        public void SetInt32(int value) { }
-        public void SetInt16(short value) { }
-        public void SetInt64(long value) { }
-        public void SetSingle(float value) { }
-        public void SetDouble(double value) { }
+        public void SetString(string value)
+        {
+            _bytes = Encoding.UTF8.GetBytes(value);
+        }
+        public void SetByte(byte value)
+        {
+            _bytes = new byte[1];
+            _bytes[0] = value;
+            AdjustBitOrder();
+        }
+        public void SetInt32(int value)
+        {
+            _bytes = BitConverter.GetBytes(value);
+            AdjustBitOrder();
+        }
+        public void SetInt16(short value)
+        {
+            _bytes = BitConverter.GetBytes(value);
+            AdjustBitOrder();
+        }
+        public void SetInt64(long value)
+        {
+            _bytes = BitConverter.GetBytes(value);
+            AdjustBitOrder();
+        }
+        public void SetSingle(float value)
+        {
+            _bytes = BitConverter.GetBytes(value);
+            AdjustBitOrder();
+        }
+        public void SetDouble(double value)
+        {
+            _bytes = BitConverter.GetBytes(value);
+            AdjustBitOrder();
+        }
         [CLSCompliant(false)]
-        public void SetSByte(sbyte value) { }
+        public void SetSByte(sbyte value)
+        {
+            _bytes = new byte[1];
+            _bytes[0] = (byte)value;
+            AdjustBitOrder();
+        }
         [CLSCompliant(false)]
-        public void SetUInt16(ushort value) { }
+        public void SetUInt16(ushort value)
+        {
+            _bytes = BitConverter.GetBytes(value);
+            AdjustBitOrder();
+        }
         [CLSCompliant(false)]
-        public void SetUInt32(uint value) { }
+        public void SetUInt32(uint value)
+        {
+            _bytes = BitConverter.GetBytes(value);
+            AdjustBitOrder();
+        }
         [CLSCompliant(false)]
-        public void SetUInt64(ulong value) { }
+        public void SetUInt64(ulong value)
+        {
+            _bytes = BitConverter.GetBytes(value);
+            AdjustBitOrder();
+        }
 
         public static implicit operator JsonNumber(byte value) { throw null; }
         public static implicit operator JsonNumber(int value) { throw null; }

--- a/src/System.Text.Json/src/System/Text/Json/Node/JsonNumber.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Node/JsonNumber.cs
@@ -9,22 +9,79 @@ namespace System.Text.Json
 {
     public partial class JsonNumber : JsonNode, IEquatable<JsonNumber>
     {
+        // number representation stored:
+        // * in big-endian if created from number
+        // * in Utf8 if created from string
+        private byte[] _bytes;
+
         public JsonNumber() { }
-        public JsonNumber(string value) { }
-        public JsonNumber(byte value) { }
-        public JsonNumber(short value) { }
-        public JsonNumber(int value) { }
-        public JsonNumber(long value) { }
-        public JsonNumber(float value) { }
-        public JsonNumber(double value) { }
+        public JsonNumber(string value)
+        {
+            _bytes = Encoding.UTF8.GetBytes(value);
+        }
+        public JsonNumber(byte value)
+        {
+            _bytes = new byte[1];
+            _bytes[0] = value;
+            AdjustBitOrder();
+        }
+        public JsonNumber(short value)
+        {
+            _bytes = BitConverter.GetBytes(value);
+            AdjustBitOrder();
+        }
+        public JsonNumber(int value)
+        {
+            _bytes = BitConverter.GetBytes(value);
+            AdjustBitOrder();
+        }
+
+        public JsonNumber(long value)
+        {
+            _bytes = BitConverter.GetBytes(value);
+            AdjustBitOrder();
+        }
+        public JsonNumber(float value)
+        {
+            _bytes = BitConverter.GetBytes(value);
+            AdjustBitOrder();
+        }
+        public JsonNumber(double value)
+        {
+            _bytes = BitConverter.GetBytes(value);
+            AdjustBitOrder();
+        }
         [CLSCompliant(false)]
-        public JsonNumber(sbyte value) { }
+        public JsonNumber(sbyte value)
+        {
+            _bytes = new byte[1];
+            _bytes[0] = (byte) value;
+            AdjustBitOrder();
+        }
         [CLSCompliant(false)]
-        public JsonNumber(ushort value) { }
+        public JsonNumber(ushort value)
+        {
+            _bytes = BitConverter.GetBytes(value);
+            AdjustBitOrder();
+        }
         [CLSCompliant(false)]
-        public JsonNumber(uint value) { }
+        public JsonNumber(uint value)
+        {
+            _bytes = BitConverter.GetBytes(value);
+            AdjustBitOrder();
+        }
         [CLSCompliant(false)]
-        public JsonNumber(ulong value) { }
+        public JsonNumber(ulong value)
+        {
+            _bytes = BitConverter.GetBytes(value);
+            AdjustBitOrder();
+        }
+
+        private void AdjustBitOrder()
+        {
+            if (BitConverter.IsLittleEndian)
+                Array.Reverse(_bytes);
+        }
 
         public string GetString() { throw null; }
         public byte GetByte() { throw null; }

--- a/src/System.Text.Json/src/System/Text/Json/Node/JsonObject.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Node/JsonObject.cs
@@ -37,6 +37,7 @@ namespace System.Text.Json
         public void Add(string propertyName, uint propertyValue) { }
         [CLSCompliant(false)]
         public void Add(string propertyName, ulong propertyValue) { }
+        public void Add(string propertyName, decimal propertyValue) { }
         public void Add(string propertyName, IEnumerable<JsonNode> propertyValue) { }
         public void AddRange(IEnumerable<KeyValuePair<string, JsonNode>> jsonProperties) { }
 

--- a/src/System.Text.Json/src/System/Text/Json/Node/JsonString.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Node/JsonString.cs
@@ -7,7 +7,7 @@
 
 namespace System.Text.Json
 {
-    public partial class JsonString : JsonNode
+    public partial class JsonString : JsonNode, IEquatable<JsonString>
     {
         public JsonString() { }
         public JsonString(string value) { }
@@ -18,6 +18,11 @@ namespace System.Text.Json
 
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
+
+        public bool Equals(JsonString other) { throw null; }
+
+        public static bool operator ==(JsonString left, JsonString right) => throw null;
+        public static bool operator !=(JsonString left, JsonString right) => throw null;
     }
 }
 

--- a/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -107,6 +107,7 @@
     <Compile Include="WritableJsonApiTests.TestTransformations.cs" />
     <Compile Include="WritableJsonApiTests.cs" />
     <Compile Include="WritableJsonApiTests.TestData.cs" />
+    <Compile Include="WritableJsonApiTests.JsonNumberUnitTests.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
     <Compile Include="$(CommonPath)\System\Buffers\ArrayBufferWriter.cs">

--- a/src/System.Text.Json/tests/WritableJsonApiTests.JsonNumberUnitTests.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.JsonNumberUnitTests.cs
@@ -12,7 +12,7 @@ namespace System.Text.Json
         [InlineData(-456)]
         [InlineData(0)]
         [InlineData(17)]
-        [InlineData(Int64.MaxValue)]
+        [InlineData(long.MaxValue)]
         [InlineData(2.3)]
         [InlineData(-17.009)]
         [InlineData(3.14f)]
@@ -28,11 +28,19 @@ namespace System.Text.Json
         }
 
         [Fact]
-        public static void TestByte()
+        public static void TestDefaultCtor()
         {
             var jsonNumber = new JsonNumber();
-            byte value = 17;
-            
+            Assert.Equal(0, jsonNumber.GetInt32());
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(17)]
+        [InlineData(255)]
+        public static void TestByte(byte value)
+        {
+            var jsonNumber = new JsonNumber();            
             jsonNumber.SetByte(value);
             byte result = jsonNumber.GetByte();
             Assert.Equal(value, result);
@@ -42,12 +50,15 @@ namespace System.Text.Json
             Assert.Equal(value, result);
         }
 
-        [Fact]
-        public static void TestShort()
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-17)]
+        [InlineData(17)]
+        [InlineData(short.MinValue)]
+        [InlineData(short.MaxValue)]
+        public static void TestShort(short value)
         {
             var jsonNumber = new JsonNumber();
-            short value = 17;
-
             jsonNumber.SetInt16(value);
             short result = jsonNumber.GetInt16();
             Assert.Equal(value, result);
@@ -57,12 +68,15 @@ namespace System.Text.Json
             Assert.Equal(value, result);
         }
 
-        [Fact]
-        public static void TestInt()
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-17)]
+        [InlineData(17)]
+        [InlineData(int.MinValue)]
+        [InlineData(int.MaxValue)]
+        public static void TestInt(int value)
         {
             var jsonNumber = new JsonNumber();
-            int value = 17;
-
             jsonNumber.SetInt32(value);
             int result = jsonNumber.GetInt32();
             Assert.Equal(value, result);
@@ -72,12 +86,15 @@ namespace System.Text.Json
             Assert.Equal(value, result);
         }
 
-        [Fact]
-        public static void TestLong()
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-17)]
+        [InlineData(17)]
+        [InlineData(long.MinValue)]
+        [InlineData(long.MaxValue)]
+        public static void TestLong(long value)
         {
             var jsonNumber = new JsonNumber();
-            long value = 17;
-
             jsonNumber.SetInt64(value);
             long result = jsonNumber.GetInt64();
             Assert.Equal(value, result);
@@ -87,12 +104,17 @@ namespace System.Text.Json
             Assert.Equal(value, result);
         }
 
-        [Fact]
-        public static void TestFloat()
+        [Theory]
+        [InlineData(0)]
+        [InlineData(17)]
+        [InlineData(-17)]
+        [InlineData(3.14)]
+        [InlineData(-15.5)]
+        [InlineData(float.MinValue)]
+        [InlineData(float.MaxValue)]
+        public static void TestFloat(float value)
         {
             var jsonNumber = new JsonNumber();
-            float value = 3.14f;
-
             jsonNumber.SetSingle(value);
             float result = jsonNumber.GetSingle();
             Assert.Equal(value, result);
@@ -102,12 +124,17 @@ namespace System.Text.Json
             Assert.Equal(value, result);
         }
 
-        [Fact]
-        public static void TestDouble()
+        [Theory]
+        [InlineData(0)]
+        [InlineData(17)]
+        [InlineData(-17)]
+        [InlineData(3.14)]
+        [InlineData(-15.5)]
+        [InlineData(double.MinValue)]
+        [InlineData(double.MaxValue)]
+        public static void TestDouble(double value)
         {
             var jsonNumber = new JsonNumber();
-            double value = 3.14;
-
             jsonNumber.SetDouble(value);
             double result = jsonNumber.GetDouble();
             Assert.Equal(value, result);
@@ -117,12 +144,15 @@ namespace System.Text.Json
             Assert.Equal(value, result);
         }
 
-        [Fact]
-        public static void TestSbyte()
+        [Theory]
+        [InlineData(0)]
+        [InlineData(17)]
+        [InlineData(-17)]
+        [InlineData(sbyte.MinValue)]
+        [InlineData(sbyte.MaxValue)]
+        public static void TestSbyte(sbyte value)
         {
             var jsonNumber = new JsonNumber();
-            sbyte value = 5;
-
             jsonNumber.SetSByte(value);
             sbyte result = jsonNumber.GetSByte();
             Assert.Equal(value, result);
@@ -132,12 +162,13 @@ namespace System.Text.Json
             Assert.Equal(value, result);
         }
 
-        [Fact]
-        public static void TestUInt16()
+        [Theory]
+        [InlineData(0)]
+        [InlineData(17)]
+        [InlineData(ushort.MaxValue)]
+        public static void TestUInt16(ushort value)
         {
             var jsonNumber = new JsonNumber();
-            ushort value = 5;
-
             jsonNumber.SetUInt16(value);
             ushort result = jsonNumber.GetUInt16();
             Assert.Equal(value, result);
@@ -147,12 +178,13 @@ namespace System.Text.Json
             Assert.Equal(value, result);
         }
 
-        [Fact]
-        public static void TestUInt32()
+        [Theory]
+        [InlineData(0)]
+        [InlineData(17)]
+        [InlineData(uint.MaxValue)]
+        public static void TestUInt32(uint value)
         {
             var jsonNumber = new JsonNumber();
-            uint value = 5;
-
             jsonNumber.SetUInt32(value);
             uint result = jsonNumber.GetUInt32();
             Assert.Equal(value, result);
@@ -162,12 +194,13 @@ namespace System.Text.Json
             Assert.Equal(value, result);
         }
 
-        [Fact]
-        public static void TestUInt64()
+        [Theory]
+        [InlineData(0)]
+        [InlineData(17)]
+        [InlineData(ulong.MaxValue)]
+        public static void TestUInt64(ulong value)
         {
             var jsonNumber = new JsonNumber();
-            ulong value = 5;
-
             jsonNumber.SetUInt64(value);
             ulong result = jsonNumber.GetUInt64();
             Assert.Equal(value, result);
@@ -188,21 +221,41 @@ namespace System.Text.Json
         public static void TestString(string value)
         {
             var jsonNumber = new JsonNumber();
-            jsonNumber.SetString(value);
-            string result = jsonNumber.GetString();
+            jsonNumber.SetFormattedValue(value);
+            string result = jsonNumber.ToString();
             Assert.Equal(value, result);
         }
 
         [Theory]
+        [InlineData("")]
         [InlineData("3,14")]
         [InlineData("this is not a number")]
         [InlineData("NAN")]
         [InlineData("0.")]
         [InlineData("008")]
+        [InlineData("0e")]
         [InlineData("5e")]
+        [InlineData("5a")]
+        [InlineData("0.1e")]
+        [InlineData("-01")]
+        [InlineData("10.5e")]
+        [InlineData("10.5e-")]
+        [InlineData("10.5e+")]
+        [InlineData("10.5e-0.2")]
+        [InlineData(" 6")]
+        [InlineData("6 ")]
+        [InlineData(" 6 ")]
+        [InlineData("+0")]
+        [InlineData("+1")]
         public static void TestInvalidString(string value)
         {
             Assert.Throws<ArgumentException>(() => new JsonNumber(value));
+        }
+
+        [Fact]
+        public static void TestNullString()
+        {
+            Assert.Throws<NullReferenceException>(() => new JsonNumber(null));
         }
 
         [Fact]

--- a/src/System.Text.Json/tests/WritableJsonApiTests.JsonNumberUnitTests.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.JsonNumberUnitTests.cs
@@ -1,0 +1,182 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Text.Json
+{
+#pragma warning disable xUnit1000
+    internal static partial class WritableJsonApiTests
+#pragma warning restore xUnit1000
+    {
+        [Theory]
+        [InlineData(-456)]
+        [InlineData(0)]
+        [InlineData(17)]
+        [InlineData(Int64.MaxValue)]
+        [InlineData(2.3)]
+        [InlineData(-17.009)]
+        [InlineData(3.14f)]
+        [InlineData(0x2A)]
+        [InlineData(0b_0010_1010)]
+        [InlineData("1e400")]
+        [InlineData("1e+100000002")]
+        [InlineData("184467440737095516150.184467440737095516150")]
+        public static void TestJsonNumberConstructor(object value)
+        {
+            // should not throw any exceptions:
+            var jsonNumber = new JsonNumber(value as dynamic);
+        }
+
+        [Fact]
+        public static void TestByte()
+        {
+            var jsonNumber = new JsonNumber();
+            byte value = 17;
+            
+            jsonNumber.SetByte(value);
+            byte result = jsonNumber.GetByte();
+            Assert.Equal(value, result);
+            
+            bool success = jsonNumber.TryGetByte(out result);
+            Assert.Equal(true, success);
+            Assert.Equal(value, result);
+        }
+
+        [Fact]
+        public static void TestShort()
+        {
+            var jsonNumber = new JsonNumber();
+            short value = 17;
+
+            jsonNumber.SetInt16(value);
+            short result = jsonNumber.GetInt16();
+            Assert.Equal(value, result);
+
+            bool success = jsonNumber.TryGetInt16(out result);
+            Assert.Equal(true, success);
+            Assert.Equal(value, result);
+        }
+
+        [Fact]
+        public static void TestInt()
+        {
+            var jsonNumber = new JsonNumber();
+            int value = 17;
+
+            jsonNumber.SetInt32(value);
+            int result = jsonNumber.GetInt32();
+            Assert.Equal(value, result);
+
+            bool success = jsonNumber.TryGetInt32(out result);
+            Assert.Equal(true, success);
+            Assert.Equal(value, result);
+        }
+
+        [Fact]
+        public static void TestLong()
+        {
+            var jsonNumber = new JsonNumber();
+            long value = 17;
+
+            jsonNumber.SetInt64(value);
+            long result = jsonNumber.GetInt64();
+            Assert.Equal(value, result);
+
+            bool success = jsonNumber.TryGetInt64(out result);
+            Assert.Equal(true, success);
+            Assert.Equal(value, result);
+        }
+
+        [Fact]
+        public static void TestFloat()
+        {
+            var jsonNumber = new JsonNumber();
+            float value = 3.14f;
+
+            jsonNumber.SetSingle(value);
+            float result = jsonNumber.GetSingle();
+            Assert.Equal(value, result);
+
+            bool success = jsonNumber.TryGetSingle(out result);
+            Assert.Equal(true, success);
+            Assert.Equal(value, result);
+        }
+
+        [Fact]
+        public static void TestDouble()
+        {
+            var jsonNumber = new JsonNumber();
+            double value = 3.14;
+
+            jsonNumber.SetDouble(value);
+            double result = jsonNumber.GetDouble();
+            Assert.Equal(value, result);
+
+            bool success = jsonNumber.TryGetDouble(out result);
+            Assert.Equal(true, success);
+            Assert.Equal(value, result);
+        }
+
+        [Fact]
+        public static void TestSbyte()
+        {
+            var jsonNumber = new JsonNumber();
+            sbyte value = 5;
+
+            jsonNumber.SetSByte(value);
+            sbyte result = jsonNumber.GetSByte();
+            Assert.Equal(value, result);
+
+            bool success = jsonNumber.TryGetSByte(out result);
+            Assert.Equal(true, success);
+            Assert.Equal(value, result);
+        }
+
+        [Fact]
+        public static void TestUInt16()
+        {
+            var jsonNumber = new JsonNumber();
+            ushort value = 5;
+
+            jsonNumber.SetUInt16(value);
+            ushort result = jsonNumber.GetUInt16();
+            Assert.Equal(value, result);
+
+            bool success = jsonNumber.TryGetUInt16(out result);
+            Assert.Equal(true, success);
+            Assert.Equal(value, result);
+        }
+
+        [Fact]
+        public static void TestUInt32()
+        {
+            var jsonNumber = new JsonNumber();
+            uint value = 5;
+
+            jsonNumber.SetUInt32(value);
+            uint result = jsonNumber.GetUInt32();
+            Assert.Equal(value, result);
+
+            bool success = jsonNumber.TryGetUInt32(out result);
+            Assert.Equal(true, success);
+            Assert.Equal(value, result);
+        }
+
+        [Fact]
+        public static void TestUInt64()
+        {
+            var jsonNumber = new JsonNumber();
+            ulong value = 5;
+
+            jsonNumber.SetUInt64(value);
+            ulong result = jsonNumber.GetUInt64();
+            Assert.Equal(value, result);
+
+            bool success = jsonNumber.TryGetUInt64(out result);
+            Assert.Equal(true, success);
+            Assert.Equal(value, result);
+        }
+    }
+}

--- a/src/System.Text.Json/tests/WritableJsonApiTests.JsonNumberUnitTests.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.JsonNumberUnitTests.cs
@@ -24,7 +24,7 @@ namespace System.Text.Json
         public static void TestJsonNumberConstructor(object value)
         {
             // should not throw any exceptions:
-            var jsonNumber = new JsonNumber(value as dynamic);
+            _ = new JsonNumber(value as dynamic);
         }
 
         [Fact]
@@ -42,11 +42,8 @@ namespace System.Text.Json
         {
             var jsonNumber = new JsonNumber();
             jsonNumber.SetByte(value);
-            byte result = jsonNumber.GetByte();
-            Assert.Equal(value, result);
-
-            bool success = jsonNumber.TryGetByte(out result);
-            Assert.True(success);
+            Assert.Equal(value, jsonNumber.GetByte());
+            Assert.True(jsonNumber.TryGetByte(out byte result));
             Assert.Equal(value, result);
         }
 
@@ -60,11 +57,8 @@ namespace System.Text.Json
         {
             var jsonNumber = new JsonNumber();
             jsonNumber.SetInt16(value);
-            short result = jsonNumber.GetInt16();
-            Assert.Equal(value, result);
-
-            bool success = jsonNumber.TryGetInt16(out result);
-            Assert.True(success);
+            Assert.Equal(value, jsonNumber.GetInt16());
+            Assert.True(jsonNumber.TryGetInt16(out short result));
             Assert.Equal(value, result);
         }
 
@@ -78,11 +72,8 @@ namespace System.Text.Json
         {
             var jsonNumber = new JsonNumber();
             jsonNumber.SetInt32(value);
-            int result = jsonNumber.GetInt32();
-            Assert.Equal(value, result);
-
-            bool success = jsonNumber.TryGetInt32(out result);
-            Assert.True(success);
+            Assert.Equal(value, jsonNumber.GetInt32());
+            Assert.True(jsonNumber.TryGetInt32(out int result));
             Assert.Equal(value, result);
         }
 
@@ -96,11 +87,8 @@ namespace System.Text.Json
         {
             var jsonNumber = new JsonNumber();
             jsonNumber.SetInt64(value);
-            long result = jsonNumber.GetInt64();
-            Assert.Equal(value, result);
-
-            bool success = jsonNumber.TryGetInt64(out result);
-            Assert.True(success);
+            Assert.Equal(value, jsonNumber.GetInt64());
+            Assert.True(jsonNumber.TryGetInt64(out long result));
             Assert.Equal(value, result);
         }
 
@@ -116,11 +104,8 @@ namespace System.Text.Json
         {
             var jsonNumber = new JsonNumber();
             jsonNumber.SetSingle(value);
-            float result = jsonNumber.GetSingle();
-            Assert.Equal(value, result);
-
-            bool success = jsonNumber.TryGetSingle(out result);
-            Assert.True(success);
+            Assert.Equal(value, jsonNumber.GetSingle());
+            Assert.True(jsonNumber.TryGetSingle(out float result));
             Assert.Equal(value, result);
         }
 
@@ -136,11 +121,8 @@ namespace System.Text.Json
         {
             var jsonNumber = new JsonNumber();
             jsonNumber.SetDouble(value);
-            double result = jsonNumber.GetDouble();
-            Assert.Equal(value, result);
-
-            bool success = jsonNumber.TryGetDouble(out result);
-            Assert.True(success);
+            Assert.Equal(value, jsonNumber.GetDouble());
+            Assert.True(jsonNumber.TryGetDouble(out double result));
             Assert.Equal(value, result);
         }
 
@@ -154,11 +136,8 @@ namespace System.Text.Json
         {
             var jsonNumber = new JsonNumber();
             jsonNumber.SetSByte(value);
-            sbyte result = jsonNumber.GetSByte();
-            Assert.Equal(value, result);
-
-            bool success = jsonNumber.TryGetSByte(out result);
-            Assert.True(success);
+            Assert.Equal(value, jsonNumber.GetSByte());
+            Assert.True(jsonNumber.TryGetSByte(out sbyte result));
             Assert.Equal(value, result);
         }
 
@@ -170,11 +149,8 @@ namespace System.Text.Json
         {
             var jsonNumber = new JsonNumber();
             jsonNumber.SetUInt16(value);
-            ushort result = jsonNumber.GetUInt16();
-            Assert.Equal(value, result);
-
-            bool success = jsonNumber.TryGetUInt16(out result);
-            Assert.True(success);
+            Assert.Equal(value, jsonNumber.GetUInt16());
+            Assert.True(jsonNumber.TryGetUInt16(out ushort result));
             Assert.Equal(value, result);
         }
 
@@ -186,11 +162,8 @@ namespace System.Text.Json
         {
             var jsonNumber = new JsonNumber();
             jsonNumber.SetUInt32(value);
-            uint result = jsonNumber.GetUInt32();
-            Assert.Equal(value, result);
-
-            bool success = jsonNumber.TryGetUInt32(out result);
-            Assert.True(success);
+            Assert.Equal(value, jsonNumber.GetUInt32());
+            Assert.True(jsonNumber.TryGetUInt32(out uint result));
             Assert.Equal(value, result);
         }
 
@@ -202,11 +175,8 @@ namespace System.Text.Json
         {
             var jsonNumber = new JsonNumber();
             jsonNumber.SetUInt64(value);
-            ulong result = jsonNumber.GetUInt64();
-            Assert.Equal(value, result);
-
-            bool success = jsonNumber.TryGetUInt64(out result);
-            Assert.True(success);
+            Assert.Equal(value, jsonNumber.GetUInt64());
+            Assert.True(jsonNumber.TryGetUInt64(out ulong result));
             Assert.Equal(value, result);
         }
 
@@ -222,8 +192,7 @@ namespace System.Text.Json
         {
             var jsonNumber = new JsonNumber();
             jsonNumber.SetFormattedValue(value);
-            string result = jsonNumber.ToString();
-            Assert.Equal(value, result);
+            Assert.Equal(value, jsonNumber.ToString());
         }
 
         [Theory]
@@ -255,15 +224,14 @@ namespace System.Text.Json
         [Fact]
         public static void TestNullString()
         {
-            Assert.Throws<NullReferenceException>(() => new JsonNumber(null));
+            Assert.Throws<ArgumentNullException>(() => new JsonNumber(null));
         }
 
         [Fact]
         public static void TestIntFromString()
         {
             var jsonNumber = new JsonNumber("145");
-            int result = jsonNumber.GetInt32();
-            Assert.Equal(145, result);
+            Assert.Equal(145, jsonNumber.GetInt32());
         }
 
         [Fact]
@@ -272,59 +240,41 @@ namespace System.Text.Json
             byte value = 17;
             var jsonNumber = new JsonNumber(value);
 
-            // Geeting other types should also succeed:
-            short shortResult = jsonNumber.GetInt16();
-            Assert.Equal(value, shortResult);
-            bool success = jsonNumber.TryGetInt16(out shortResult);
-            Assert.True(success);
+            // Getting other types should also succeed:
+            Assert.Equal(value, jsonNumber.GetInt16());
+            Assert.True(jsonNumber.TryGetInt16(out short shortResult));
             Assert.Equal(value, shortResult);
 
-            int intResult = jsonNumber.GetInt32();
-            Assert.Equal(value, intResult);
-            success = jsonNumber.TryGetInt32(out intResult);
-            Assert.True(success);
+            Assert.Equal(value, jsonNumber.GetInt32());
+            Assert.True(jsonNumber.TryGetInt32(out int intResult));
             Assert.Equal(value, intResult);
 
-            long longResult = jsonNumber.GetInt64();
-            Assert.Equal(value, longResult);
-            success = jsonNumber.TryGetInt64(out longResult);
-            Assert.True(success);
+            Assert.Equal(value, jsonNumber.GetInt64());
+            Assert.True(jsonNumber.TryGetInt64(out long longResult));
             Assert.Equal(value, longResult);
 
-            float floatResult = jsonNumber.GetSingle();
-            Assert.Equal(value, floatResult);
-            success = jsonNumber.TryGetSingle(out floatResult);
-            Assert.True(success);
+            Assert.Equal(value, jsonNumber.GetSingle());
+            Assert.True(jsonNumber.TryGetSingle(out float floatResult));
             Assert.Equal(value, floatResult);
 
-            double doubleResult = jsonNumber.GetDouble();
-            Assert.Equal(value, doubleResult);
-            success = jsonNumber.TryGetDouble(out doubleResult);
-            Assert.True(success);
+            Assert.Equal(value, jsonNumber.GetDouble());
+            Assert.True(jsonNumber.TryGetDouble(out double doubleResult));
             Assert.Equal(value, doubleResult);
 
-            sbyte sbyteResult = jsonNumber.GetSByte();
-            Assert.Equal(value, (byte)sbyteResult);
-            success = jsonNumber.TryGetSByte(out sbyteResult);
-            Assert.True(success);
+            Assert.Equal(value, (byte)jsonNumber.GetSByte());
+            Assert.True(jsonNumber.TryGetSByte(out sbyte sbyteResult));
             Assert.Equal(value, (byte)sbyteResult);
 
-            ushort ushortResult = jsonNumber.GetUInt16();
-            Assert.Equal(value, ushortResult);
-            success = jsonNumber.TryGetUInt16(out ushortResult);
-            Assert.True(success);
+            Assert.Equal(value, jsonNumber.GetUInt16());
+            Assert.True(jsonNumber.TryGetUInt16(out ushort ushortResult));
             Assert.Equal(value, ushortResult);
 
-            uint uintResult = jsonNumber.GetUInt32();
-            Assert.Equal(value, uintResult);
-            success = jsonNumber.TryGetUInt32(out uintResult);
-            Assert.True(success);
+            Assert.Equal(value, jsonNumber.GetUInt32());
+            Assert.True(jsonNumber.TryGetUInt32(out uint uintResult));
             Assert.Equal(value, uintResult);
 
-            ulong ulongResult = jsonNumber.GetUInt64();
-            Assert.Equal(value, ulongResult);
-            success = jsonNumber.TryGetUInt64(out ulongResult);
-            Assert.True(success);
+            Assert.Equal(value, jsonNumber.GetUInt64());
+            Assert.True(jsonNumber.TryGetUInt64(out ulong ulongResult));
             Assert.Equal(value, ulongResult);
         }
 
@@ -333,29 +283,23 @@ namespace System.Text.Json
         {
             var jsonNumber = new JsonNumber(long.MaxValue);
 
-            // Geeting smaller types should fail:
-            bool success = jsonNumber.TryGetByte(out byte byteResult);
-            Assert.False(success);
+            // Getting smaller types should fail:
+            Assert.False(jsonNumber.TryGetByte(out byte byteResult));
             Assert.Throws<OverflowException>(() => jsonNumber.GetByte());
 
-            success = jsonNumber.TryGetInt16(out short shortResult);
-            Assert.False(success);
+            Assert.False(jsonNumber.TryGetInt16(out short shortResult));
             Assert.Throws<OverflowException>(() => jsonNumber.GetInt16());
 
-            success = jsonNumber.TryGetInt32(out int intResult);
-            Assert.False(success);
+            Assert.False(jsonNumber.TryGetInt32(out int intResult));
             Assert.Throws<OverflowException>(() => jsonNumber.GetInt32());
 
-            success = jsonNumber.TryGetSByte(out sbyte sbyteResult);
-            Assert.False(success);
+            Assert.False(jsonNumber.TryGetSByte(out sbyte sbyteResult));
             Assert.Throws<OverflowException>(() => jsonNumber.GetSByte());
 
-            success = jsonNumber.TryGetUInt16(out ushort ushortResult);
-            Assert.False(success);
+            Assert.False(jsonNumber.TryGetUInt16(out ushort ushortResult));
             Assert.Throws<OverflowException>(() => jsonNumber.GetUInt16());
 
-            success = jsonNumber.TryGetUInt32(out uint uintResult);
-            Assert.False(success);
+            Assert.False(jsonNumber.TryGetUInt32(out uint uintResult));
             Assert.Throws<OverflowException>(() => jsonNumber.GetUInt32());
         }
 
@@ -364,21 +308,17 @@ namespace System.Text.Json
         {
             var jsonNumber = new JsonNumber("-1");
 
-            // Geeting unsigned types should fail:
-            bool success = jsonNumber.TryGetByte(out byte byteResult);
-            Assert.False(success);
+            // Getting unsigned types should fail:
+            Assert.False(jsonNumber.TryGetByte(out byte byteResult));
             Assert.Throws<OverflowException>(() => jsonNumber.GetByte());
 
-            success = jsonNumber.TryGetUInt16(out ushort ushortResult);
-            Assert.False(success);
+            Assert.False(jsonNumber.TryGetUInt16(out ushort ushortResult));
             Assert.Throws<OverflowException>(() => jsonNumber.GetUInt16());
 
-            success = jsonNumber.TryGetUInt32(out uint uintResult);
-            Assert.False(success);
+            Assert.False(jsonNumber.TryGetUInt32(out uint uintResult));
             Assert.Throws<OverflowException>(() => jsonNumber.GetUInt32());
 
-            success = jsonNumber.TryGetUInt64(out ulong ulongResult);
-            Assert.False(success);
+            Assert.False(jsonNumber.TryGetUInt64(out ulong ulongResult));
             Assert.Throws<OverflowException>(() => jsonNumber.GetUInt64());
         }
 
@@ -387,37 +327,29 @@ namespace System.Text.Json
         {
             var jsonNumber = new JsonNumber("3.14");
 
-            // Geeting integer types should fail:
-            bool success = jsonNumber.TryGetByte(out byte byteResult);
-            Assert.False(success);
+            // Getting integer types should fail:
+            Assert.False(jsonNumber.TryGetByte(out byte byteResult));
             Assert.Throws<FormatException>(() => jsonNumber.GetByte());
 
-            success = jsonNumber.TryGetInt16(out short shortResult);
-            Assert.False(success);
+            Assert.False(jsonNumber.TryGetInt16(out short shortResult));
             Assert.Throws<FormatException>(() => jsonNumber.GetInt16());
 
-            success = jsonNumber.TryGetInt32(out int intResult);
-            Assert.False(success);
+            Assert.False(jsonNumber.TryGetInt32(out int intResult));
             Assert.Throws<FormatException>(() => jsonNumber.GetInt32());
 
-            success = jsonNumber.TryGetInt64(out long longResult);
-            Assert.False(success);
+            Assert.False(jsonNumber.TryGetInt64(out long longResult));
             Assert.Throws<FormatException>(() => jsonNumber.GetInt64());
 
-            success = jsonNumber.TryGetSByte(out sbyte sbyteResult);
-            Assert.False(success);
+            Assert.False(jsonNumber.TryGetSByte(out sbyte sbyteResult));
             Assert.Throws<FormatException>(() => jsonNumber.GetSByte());
 
-            success = jsonNumber.TryGetUInt16(out ushort ushortResult);
-            Assert.False(success);
+            Assert.False(jsonNumber.TryGetUInt16(out ushort ushortResult));
             Assert.Throws<FormatException>(() => jsonNumber.GetUInt16());
 
-            success = jsonNumber.TryGetUInt32(out uint uintResult);
-            Assert.False(success);
+            Assert.False(jsonNumber.TryGetUInt32(out uint uintResult));
             Assert.Throws<FormatException>(() => jsonNumber.GetUInt32());
 
-            success = jsonNumber.TryGetUInt64(out ulong ulongResult);
-            Assert.False(success);
+            Assert.False(jsonNumber.TryGetUInt64(out ulong ulongResult));
             Assert.Throws<FormatException>(() => jsonNumber.GetUInt64());
         }
 

--- a/src/System.Text.Json/tests/WritableJsonApiTests.JsonNumberUnitTests.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.JsonNumberUnitTests.cs
@@ -40,11 +40,11 @@ namespace System.Text.Json
         [InlineData(255)]
         public static void TestByte(byte value)
         {
-            var jsonNumber = new JsonNumber();            
+            var jsonNumber = new JsonNumber();
             jsonNumber.SetByte(value);
             byte result = jsonNumber.GetByte();
             Assert.Equal(value, result);
-            
+
             bool success = jsonNumber.TryGetByte(out result);
             Assert.True(success);
             Assert.Equal(value, result);
@@ -264,6 +264,161 @@ namespace System.Text.Json
             var jsonNumber = new JsonNumber("145");
             int result = jsonNumber.GetInt32();
             Assert.Equal(145, result);
+        }
+
+        [Fact]
+        public static void TestUpcasts()
+        {
+            byte value = 17;
+            var jsonNumber = new JsonNumber(value);
+
+            // Geeting other types should also succeed:
+            short shortResult = jsonNumber.GetInt16();
+            Assert.Equal(value, shortResult);
+            bool success = jsonNumber.TryGetInt16(out shortResult);
+            Assert.True(success);
+            Assert.Equal(value, shortResult);
+
+            int intResult = jsonNumber.GetInt32();
+            Assert.Equal(value, intResult);
+            success = jsonNumber.TryGetInt32(out intResult);
+            Assert.True(success);
+            Assert.Equal(value, intResult);
+
+            long longResult = jsonNumber.GetInt64();
+            Assert.Equal(value, longResult);
+            success = jsonNumber.TryGetInt64(out longResult);
+            Assert.True(success);
+            Assert.Equal(value, longResult);
+
+            float floatResult = jsonNumber.GetSingle();
+            Assert.Equal(value, floatResult);
+            success = jsonNumber.TryGetSingle(out floatResult);
+            Assert.True(success);
+            Assert.Equal(value, floatResult);
+
+            double doubleResult = jsonNumber.GetDouble();
+            Assert.Equal(value, doubleResult);
+            success = jsonNumber.TryGetDouble(out doubleResult);
+            Assert.True(success);
+            Assert.Equal(value, doubleResult);
+
+            sbyte sbyteResult = jsonNumber.GetSByte();
+            Assert.Equal(value, (byte)sbyteResult);
+            success = jsonNumber.TryGetSByte(out sbyteResult);
+            Assert.True(success);
+            Assert.Equal(value, (byte)sbyteResult);
+
+            ushort ushortResult = jsonNumber.GetUInt16();
+            Assert.Equal(value, ushortResult);
+            success = jsonNumber.TryGetUInt16(out ushortResult);
+            Assert.True(success);
+            Assert.Equal(value, ushortResult);
+
+            uint uintResult = jsonNumber.GetUInt32();
+            Assert.Equal(value, uintResult);
+            success = jsonNumber.TryGetUInt32(out uintResult);
+            Assert.True(success);
+            Assert.Equal(value, uintResult);
+
+            ulong ulongResult = jsonNumber.GetUInt64();
+            Assert.Equal(value, ulongResult);
+            success = jsonNumber.TryGetUInt64(out ulongResult);
+            Assert.True(success);
+            Assert.Equal(value, ulongResult);
+        }
+
+        [Fact]
+        public static void TestIntegerGetMismatches()
+        {
+            var jsonNumber = new JsonNumber(long.MaxValue);
+
+            // Geeting smaller types should fail:
+            bool success = jsonNumber.TryGetByte(out byte byteResult);
+            Assert.False(success);
+            Assert.Throws<OverflowException>(() => jsonNumber.GetByte());
+
+            success = jsonNumber.TryGetInt16(out short shortResult);
+            Assert.False(success);
+            Assert.Throws<OverflowException>(() => jsonNumber.GetInt16());
+
+            success = jsonNumber.TryGetInt32(out int intResult);
+            Assert.False(success);
+            Assert.Throws<OverflowException>(() => jsonNumber.GetInt32());
+
+            success = jsonNumber.TryGetSByte(out sbyte sbyteResult);
+            Assert.False(success);
+            Assert.Throws<OverflowException>(() => jsonNumber.GetSByte());
+
+            success = jsonNumber.TryGetUInt16(out ushort ushortResult);
+            Assert.False(success);
+            Assert.Throws<OverflowException>(() => jsonNumber.GetUInt16());
+
+            success = jsonNumber.TryGetUInt32(out uint uintResult);
+            Assert.False(success);
+            Assert.Throws<OverflowException>(() => jsonNumber.GetUInt32());
+        }
+
+        [Fact]
+        public static void TestUnsignedGetMismatches()
+        {
+            var jsonNumber = new JsonNumber("-1");
+
+            // Geeting unsigned types should fail:
+            bool success = jsonNumber.TryGetByte(out byte byteResult);
+            Assert.False(success);
+            Assert.Throws<OverflowException>(() => jsonNumber.GetByte());
+
+            success = jsonNumber.TryGetUInt16(out ushort ushortResult);
+            Assert.False(success);
+            Assert.Throws<OverflowException>(() => jsonNumber.GetUInt16());
+
+            success = jsonNumber.TryGetUInt32(out uint uintResult);
+            Assert.False(success);
+            Assert.Throws<OverflowException>(() => jsonNumber.GetUInt32());
+
+            success = jsonNumber.TryGetUInt64(out ulong ulongResult);
+            Assert.False(success);
+            Assert.Throws<OverflowException>(() => jsonNumber.GetUInt64());
+        }
+
+        [Fact]
+        public static void TestRationalGetMismatches()
+        {
+            var jsonNumber = new JsonNumber("3.14");
+
+            // Geeting integer types should fail:
+            bool success = jsonNumber.TryGetByte(out byte byteResult);
+            Assert.False(success);
+            Assert.Throws<FormatException>(() => jsonNumber.GetByte());
+
+            success = jsonNumber.TryGetInt16(out short shortResult);
+            Assert.False(success);
+            Assert.Throws<FormatException>(() => jsonNumber.GetInt16());
+
+            success = jsonNumber.TryGetInt32(out int intResult);
+            Assert.False(success);
+            Assert.Throws<FormatException>(() => jsonNumber.GetInt32());
+
+            success = jsonNumber.TryGetInt64(out long longResult);
+            Assert.False(success);
+            Assert.Throws<FormatException>(() => jsonNumber.GetInt64());
+
+            success = jsonNumber.TryGetSByte(out sbyte sbyteResult);
+            Assert.False(success);
+            Assert.Throws<FormatException>(() => jsonNumber.GetSByte());
+
+            success = jsonNumber.TryGetUInt16(out ushort ushortResult);
+            Assert.False(success);
+            Assert.Throws<FormatException>(() => jsonNumber.GetUInt16());
+
+            success = jsonNumber.TryGetUInt32(out uint uintResult);
+            Assert.False(success);
+            Assert.Throws<FormatException>(() => jsonNumber.GetUInt32());
+
+            success = jsonNumber.TryGetUInt64(out ulong ulongResult);
+            Assert.False(success);
+            Assert.Throws<FormatException>(() => jsonNumber.GetUInt64());
         }
     }
 }

--- a/src/System.Text.Json/tests/WritableJsonApiTests.JsonNumberUnitTests.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.JsonNumberUnitTests.cs
@@ -19,7 +19,7 @@ namespace System.Text.Json
         [InlineData(-17.009)]
         [InlineData(3.14f)]
         [InlineData(0x2A)]
-        [InlineData(0b_0010_1010)]
+        [InlineData(0b_0110_1010)]
         [InlineData("1e400")]
         [InlineData("1e+100000002")]
         [InlineData("184467440737095516150.184467440737095516150")]
@@ -40,7 +40,7 @@ namespace System.Text.Json
             Assert.Equal(value, result);
             
             bool success = jsonNumber.TryGetByte(out result);
-            Assert.Equal(true, success);
+            Assert.True(success);
             Assert.Equal(value, result);
         }
 
@@ -55,7 +55,7 @@ namespace System.Text.Json
             Assert.Equal(value, result);
 
             bool success = jsonNumber.TryGetInt16(out result);
-            Assert.Equal(true, success);
+            Assert.True(success);
             Assert.Equal(value, result);
         }
 
@@ -70,7 +70,7 @@ namespace System.Text.Json
             Assert.Equal(value, result);
 
             bool success = jsonNumber.TryGetInt32(out result);
-            Assert.Equal(true, success);
+            Assert.True(success);
             Assert.Equal(value, result);
         }
 
@@ -85,7 +85,7 @@ namespace System.Text.Json
             Assert.Equal(value, result);
 
             bool success = jsonNumber.TryGetInt64(out result);
-            Assert.Equal(true, success);
+            Assert.True(success);
             Assert.Equal(value, result);
         }
 
@@ -100,7 +100,7 @@ namespace System.Text.Json
             Assert.Equal(value, result);
 
             bool success = jsonNumber.TryGetSingle(out result);
-            Assert.Equal(true, success);
+            Assert.True(success);
             Assert.Equal(value, result);
         }
 
@@ -115,7 +115,7 @@ namespace System.Text.Json
             Assert.Equal(value, result);
 
             bool success = jsonNumber.TryGetDouble(out result);
-            Assert.Equal(true, success);
+            Assert.True(success);
             Assert.Equal(value, result);
         }
 
@@ -130,7 +130,7 @@ namespace System.Text.Json
             Assert.Equal(value, result);
 
             bool success = jsonNumber.TryGetSByte(out result);
-            Assert.Equal(true, success);
+            Assert.True(success);
             Assert.Equal(value, result);
         }
 
@@ -145,7 +145,7 @@ namespace System.Text.Json
             Assert.Equal(value, result);
 
             bool success = jsonNumber.TryGetUInt16(out result);
-            Assert.Equal(true, success);
+            Assert.True(success);
             Assert.Equal(value, result);
         }
 
@@ -160,7 +160,7 @@ namespace System.Text.Json
             Assert.Equal(value, result);
 
             bool success = jsonNumber.TryGetUInt32(out result);
-            Assert.Equal(true, success);
+            Assert.True(success);
             Assert.Equal(value, result);
         }
 
@@ -175,7 +175,7 @@ namespace System.Text.Json
             Assert.Equal(value, result);
 
             bool success = jsonNumber.TryGetUInt64(out result);
-            Assert.Equal(true, success);
+            Assert.True(success);
             Assert.Equal(value, result);
         }
     }

--- a/src/System.Text.Json/tests/WritableJsonApiTests.JsonNumberUnitTests.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.JsonNumberUnitTests.cs
@@ -6,9 +6,7 @@ using Xunit;
 
 namespace System.Text.Json
 {
-//#pragma warning disable xUnit1000
     public static partial class WritableJsonApiTests
-//#pragma warning restore xUnit1000
     {
         [Theory]
         [InlineData(-456)]

--- a/src/System.Text.Json/tests/WritableJsonApiTests.JsonNumberUnitTests.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.JsonNumberUnitTests.cs
@@ -420,5 +420,56 @@ namespace System.Text.Json
             Assert.False(success);
             Assert.Throws<FormatException>(() => jsonNumber.GetUInt64());
         }
+
+        [Theory]
+        [InlineData("0")]
+        [InlineData("-17")]
+        [InlineData("17")]
+        [InlineData("3.14")]
+        [InlineData("-3.1415")]
+        [InlineData("1234567890")]
+        [InlineData("1e400")]
+        [InlineData("1e+100000002")]
+        [InlineData("184467440737095516150.184467440737095516150")]
+        public static void TestToString(string value)
+        {
+            var jsonNumber = new JsonNumber();
+            jsonNumber.SetFormattedValue(value);
+            Assert.Equal(value, jsonNumber.ToString());
+        }
+
+        [Fact]
+        public static void TestChangingTypes()
+        {
+            var jsonNumber = new JsonNumber(5);
+            Assert.Equal(5, jsonNumber.GetInt32());
+
+            jsonNumber.SetDouble(3.14);
+            Assert.Equal(3.14, jsonNumber.GetDouble());
+
+            jsonNumber.SetByte(17);
+            Assert.Equal(17, jsonNumber.GetByte());
+
+            jsonNumber.SetInt64(long.MaxValue);
+            Assert.Equal(long.MaxValue, jsonNumber.GetInt64());
+
+            jsonNumber.SetUInt16(ushort.MaxValue);
+            Assert.Equal(ushort.MaxValue, jsonNumber.GetUInt16());
+
+            jsonNumber.SetSingle(-1.1f);
+            Assert.Equal(-1.1f, jsonNumber.GetSingle());
+
+            jsonNumber.SetSByte(4);
+            Assert.Equal(4, jsonNumber.GetSByte());
+
+            jsonNumber.SetUInt32(127);
+            Assert.Equal((uint)127, jsonNumber.GetUInt32());
+
+            jsonNumber.SetFormattedValue("1e400");
+            Assert.Equal("1e400", jsonNumber.ToString());
+
+            jsonNumber.SetUInt64(ulong.MaxValue);
+            Assert.Equal(ulong.MaxValue, jsonNumber.GetUInt64());
+        }
     }
 }

--- a/src/System.Text.Json/tests/WritableJsonApiTests.JsonNumberUnitTests.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.JsonNumberUnitTests.cs
@@ -180,6 +180,17 @@ namespace System.Text.Json
             Assert.Equal(value, result);
         }
 
+        [Fact]
+        public static void TestDecimal()
+        {
+            var decimalValue = decimal.MaxValue;
+            var jsonNumber = new JsonNumber();
+            jsonNumber.SetDecimal(decimalValue);
+            Assert.Equal(decimalValue, jsonNumber.GetDecimal());
+            Assert.True(jsonNumber.TryGetDecimal(out decimal result));
+            Assert.Equal(decimalValue, result);
+        }
+
         [Theory]
         [InlineData("3.14")]
         [InlineData("-17")]
@@ -276,6 +287,10 @@ namespace System.Text.Json
             Assert.Equal(value, jsonNumber.GetUInt64());
             Assert.True(jsonNumber.TryGetUInt64(out ulong ulongResult));
             Assert.Equal(value, ulongResult);
+
+            Assert.Equal(value, jsonNumber.GetDecimal());
+            Assert.True(jsonNumber.TryGetDecimal(out decimal decimalResult));
+            Assert.Equal(value, decimalResult);
         }
 
         [Fact]
@@ -402,6 +417,9 @@ namespace System.Text.Json
 
             jsonNumber.SetUInt64(ulong.MaxValue);
             Assert.Equal(ulong.MaxValue, jsonNumber.GetUInt64());
+
+            jsonNumber.SetDecimal(decimal.MaxValue);
+            Assert.Equal(decimal.MaxValue, jsonNumber.GetDecimal());
         }
 
         [Fact]
@@ -446,6 +464,10 @@ namespace System.Text.Json
             ulong ulongValue = ulong.MaxValue;
             jsonNumber = ulongValue;
             Assert.Equal(ulongValue, jsonNumber.GetUInt64());
+
+            decimal decimalValue = decimal.MaxValue;
+            jsonNumber = decimalValue;
+            Assert.Equal(decimalValue, jsonNumber.GetDecimal());
         }
     }
 }

--- a/src/System.Text.Json/tests/WritableJsonApiTests.JsonNumberUnitTests.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.JsonNumberUnitTests.cs
@@ -6,9 +6,9 @@ using Xunit;
 
 namespace System.Text.Json
 {
-#pragma warning disable xUnit1000
-    internal static partial class WritableJsonApiTests
-#pragma warning restore xUnit1000
+//#pragma warning disable xUnit1000
+    public static partial class WritableJsonApiTests
+//#pragma warning restore xUnit1000
     {
         [Theory]
         [InlineData(-456)]

--- a/src/System.Text.Json/tests/WritableJsonApiTests.JsonNumberUnitTests.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.JsonNumberUnitTests.cs
@@ -471,5 +471,49 @@ namespace System.Text.Json
             jsonNumber.SetUInt64(ulong.MaxValue);
             Assert.Equal(ulong.MaxValue, jsonNumber.GetUInt64());
         }
+
+        [Fact]
+        public static void TestImplicitOperators()
+        {
+            byte byteValue = byte.MaxValue;
+            JsonNumber jsonNumber = byteValue;
+            Assert.Equal(byteValue, jsonNumber.GetByte());
+
+            short shortValue = short.MaxValue;
+            jsonNumber = shortValue;
+            Assert.Equal(shortValue, jsonNumber.GetInt16());
+
+            int intValue = int.MaxValue;
+            jsonNumber = intValue;
+            Assert.Equal(intValue, jsonNumber.GetInt32());
+
+            long longValue = long.MaxValue;
+            jsonNumber = longValue;
+            Assert.Equal(longValue, jsonNumber.GetInt64());
+
+            float floatValue = float.MaxValue;
+            jsonNumber = floatValue;
+            Assert.Equal(floatValue, jsonNumber.GetSingle());
+
+            double doubleValue = double.MaxValue;
+            jsonNumber = doubleValue;
+            Assert.Equal(doubleValue, jsonNumber.GetDouble());
+
+            sbyte sbyteValue = sbyte.MaxValue;
+            jsonNumber = sbyteValue;
+            Assert.Equal(sbyteValue, jsonNumber.GetSByte());
+
+            ushort ushortValue = ushort.MaxValue;
+            jsonNumber = ushortValue;
+            Assert.Equal(ushortValue, jsonNumber.GetUInt16());
+
+            uint uintValue = uint.MaxValue;
+            jsonNumber = uintValue;
+            Assert.Equal(uintValue, jsonNumber.GetUInt32());
+
+            ulong ulongValue = ulong.MaxValue;
+            jsonNumber = ulongValue;
+            Assert.Equal(ulongValue, jsonNumber.GetUInt64());
+        }
     }
 }

--- a/src/System.Text.Json/tests/WritableJsonApiTests.JsonNumberUnitTests.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.JsonNumberUnitTests.cs
@@ -178,5 +178,41 @@ namespace System.Text.Json
             Assert.True(success);
             Assert.Equal(value, result);
         }
+
+        [Theory]
+        [InlineData("3.14")]
+        [InlineData("-17")]
+        [InlineData("0")]
+        [InlineData("189")]
+        [InlineData("1e400")]
+        [InlineData("1e+100000002")]
+        [InlineData("184467440737095516150.184467440737095516150")]
+        public static void TestString(string value)
+        {
+            var jsonNumber = new JsonNumber();
+            jsonNumber.SetString(value);
+            string result = jsonNumber.GetString();
+            Assert.Equal(value, result);
+        }
+
+        [Theory]
+        [InlineData("3,14")]
+        [InlineData("this is not a number")]
+        [InlineData("NAN")]
+        [InlineData("0.")]
+        [InlineData("008")]
+        [InlineData("5e")]
+        public static void TestInvalidString(string value)
+        {
+            Assert.Throws<ArgumentException>(() => new JsonNumber(value));
+        }
+
+        [Fact]
+        public static void TestIntFromString()
+        {
+            var jsonNumber = new JsonNumber("145");
+            int result = jsonNumber.GetInt32();
+            Assert.Equal(145, result);
+        }
     }
 }

--- a/src/System.Text.Json/tests/WritableJsonApiTests.TestAccessingNestedMembers.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.TestAccessingNestedMembers.cs
@@ -6,9 +6,9 @@ using Xunit;
 
 namespace System.Text.Json
 {
-#pragma warning disable xUnit1000
-    internal static partial class WritableJsonApiTests
-#pragma warning restore xUnit1000
+//#pragma warning disable xUnit1000
+    public static partial class WritableJsonApiTests
+//#pragma warning restore xUnit1000
     {
         /// <summary>
         /// Accesing nested Json object - casting with as operator

--- a/src/System.Text.Json/tests/WritableJsonApiTests.TestAccessingNestedMembers.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.TestAccessingNestedMembers.cs
@@ -6,9 +6,7 @@ using Xunit;
 
 namespace System.Text.Json
 {
-//#pragma warning disable xUnit1000
     public static partial class WritableJsonApiTests
-//#pragma warning restore xUnit1000
     {
         /// <summary>
         /// Accesing nested Json object - casting with as operator

--- a/src/System.Text.Json/tests/WritableJsonApiTests.TestAccessingNestedMembers.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.TestAccessingNestedMembers.cs
@@ -139,8 +139,8 @@ namespace System.Text.Json
             ((JsonString)issues.GetJsonArrayProperty("features")[1]).Value = "feature 56134";
 
             Assert.True(((JsonArray)issues["bugs"]).Contains("bug 12356"));
-            Assert.Equal((JsonString)((JsonArray)issues["features"])[0], "feature 1569");
-            Assert.Equal((JsonString)((JsonArray)issues["features"])[1], "feature 56134");
+            Assert.Equal("feature 1569", (JsonString)((JsonArray)issues["features"])[0]);
+            Assert.Equal("feature 56134", (JsonString)((JsonArray)issues["features"])[1]);
         }
     }
 }

--- a/src/System.Text.Json/tests/WritableJsonApiTests.TestAccessingNestedMembers.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.TestAccessingNestedMembers.cs
@@ -8,7 +8,7 @@ namespace System.Text.Json
 {
 #pragma warning disable xUnit1000
     internal static partial class WritableJsonApiTests
-#pragma warning enable xUnit1000
+#pragma warning restore xUnit1000
     {
         /// <summary>
         /// Accesing nested Json object - casting with as operator

--- a/src/System.Text.Json/tests/WritableJsonApiTests.TestData.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.TestData.cs
@@ -8,7 +8,7 @@ namespace System.Text.Json
 {
 #pragma warning disable xUnit1000
     internal static partial class WritableJsonApiTests
-#pragma warning enable xUnit1000
+#pragma warning restore xUnit1000
     {
         /// <summary>
         /// Helper class simulating external library

--- a/src/System.Text.Json/tests/WritableJsonApiTests.TestData.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.TestData.cs
@@ -6,9 +6,9 @@ using System.Collections.Generic;
 
 namespace System.Text.Json
 {
-#pragma warning disable xUnit1000
-    internal static partial class WritableJsonApiTests
-#pragma warning restore xUnit1000
+//#pragma warning disable xUnit1000
+    public static partial class WritableJsonApiTests
+//#pragma warning restore xUnit1000
     {
         /// <summary>
         /// Helper class simulating external library

--- a/src/System.Text.Json/tests/WritableJsonApiTests.TestData.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.TestData.cs
@@ -6,9 +6,7 @@ using System.Collections.Generic;
 
 namespace System.Text.Json
 {
-//#pragma warning disable xUnit1000
     public static partial class WritableJsonApiTests
-//#pragma warning restore xUnit1000
     {
         /// <summary>
         /// Helper class simulating external library

--- a/src/System.Text.Json/tests/WritableJsonApiTests.TestModifying.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.TestModifying.cs
@@ -7,9 +7,9 @@ using Xunit;
 
 namespace System.Text.Json
 {
-#pragma warning disable xUnit1000
-    internal static partial class WritableJsonApiTests
-#pragma warning restore xUnit1000
+//#pragma warning disable xUnit1000
+    public static partial class WritableJsonApiTests
+//#pragma warning restore xUnit1000
     {
         /// <summary>
         /// Replacing Json object's primnary types

--- a/src/System.Text.Json/tests/WritableJsonApiTests.TestModifying.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.TestModifying.cs
@@ -9,7 +9,7 @@ namespace System.Text.Json
 {
 #pragma warning disable xUnit1000
     internal static partial class WritableJsonApiTests
-#pragma warning enable xUnit1000
+#pragma warning restore xUnit1000
     {
         /// <summary>
         /// Replacing Json object's primnary types

--- a/src/System.Text.Json/tests/WritableJsonApiTests.TestModifying.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.TestModifying.cs
@@ -7,9 +7,7 @@ using Xunit;
 
 namespace System.Text.Json
 {
-//#pragma warning disable xUnit1000
     public static partial class WritableJsonApiTests
-//#pragma warning restore xUnit1000
     {
         /// <summary>
         /// Replacing Json object's primnary types

--- a/src/System.Text.Json/tests/WritableJsonApiTests.TestModifying.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.TestModifying.cs
@@ -81,8 +81,8 @@ namespace System.Text.Json
             Assert.True(isEnabled.Value);
 
             JsonNumber veryBigConstant = new JsonNumber();
-            veryBigConstant.SetString("1e1000");
-            string bigNumber = veryBigConstant.GetString();
+            veryBigConstant.SetFormattedValue("1e1000");
+            string bigNumber = veryBigConstant.ToString();
 
             Assert.Equal("1e1000", bigNumber);
 

--- a/src/System.Text.Json/tests/WritableJsonApiTests.TestModifying.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.TestModifying.cs
@@ -28,20 +28,20 @@ namespace System.Text.Json
             person1["name"] = new JsonString("Bob");
 
             Assert.IsType<JsonString>(person1["name"]);
-            Assert.Equal(person1["name"] as JsonString, "Bob");
+            Assert.Equal("Bob", person1["name"] as JsonString);
 
             // Assign by using an implicit operator on primary Json type
             JsonNumber newAge = 55;
             person1["age"] = newAge;
 
             Assert.IsType<JsonNumber>(person1["age"]);
-            Assert.Equal(person1["age"] as JsonNumber, 55);
+            Assert.Equal(55, person1["age"] as JsonNumber);
 
             // Assign by explicit cast from Json primary type
             person1["is_married"] = (JsonBoolean)false;
 
             Assert.IsType<JsonBoolean>(person1["is_married"]);
-            Assert.Equal(person1["is_married"] as JsonBoolean, false);
+            Assert.Equal(false, person1["is_married"] as JsonBoolean);
 
             // Not possible scenario (wold require implicit cast operators in JsonNode):
             // person["name"] = "Bob";
@@ -57,7 +57,7 @@ namespace System.Text.Json
             person1["age"] = person2["age"];
 
             Assert.IsType<JsonNumber>(person1["age"]);
-            Assert.Equal(person1["age"] as JsonNumber, 33);
+            Assert.Equal(33, person1["age"] as JsonNumber);
 
             // Copy property of different typoe
             person1["name"] = person2["name"];

--- a/src/System.Text.Json/tests/WritableJsonApiTests.TestTransformations.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.TestTransformations.cs
@@ -8,9 +8,7 @@ using Xunit;
 
 namespace System.Text.Json
 {
-//#pragma warning disable xUnit1000
     public static partial class WritableJsonApiTests
-//#pragma warning restore xUnit1000
     {
         /// <summary>
         /// Transforming JsoneNode to JsonElement

--- a/src/System.Text.Json/tests/WritableJsonApiTests.TestTransformations.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.TestTransformations.cs
@@ -10,7 +10,7 @@ namespace System.Text.Json
 {
 #pragma warning disable xUnit1000
     internal static partial class WritableJsonApiTests
-#pragma warning enable xUnit1000
+#pragma warning restore xUnit1000
     {
         /// <summary>
         /// Transforming JsoneNode to JsonElement

--- a/src/System.Text.Json/tests/WritableJsonApiTests.TestTransformations.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.TestTransformations.cs
@@ -8,9 +8,9 @@ using Xunit;
 
 namespace System.Text.Json
 {
-#pragma warning disable xUnit1000
-    internal static partial class WritableJsonApiTests
-#pragma warning restore xUnit1000
+//#pragma warning disable xUnit1000
+    public static partial class WritableJsonApiTests
+//#pragma warning restore xUnit1000
     {
         /// <summary>
         /// Transforming JsoneNode to JsonElement

--- a/src/System.Text.Json/tests/WritableJsonApiTests.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.cs
@@ -10,7 +10,7 @@ namespace System.Text.Json
 {
 #pragma warning disable xUnit1000
     internal static partial class WritableJsonApiTests
-#pragma warning enable xUnit1000
+#pragma warning restore xUnit1000
     {
         /// <summary>
         /// Creating simple Json object

--- a/src/System.Text.Json/tests/WritableJsonApiTests.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.cs
@@ -8,9 +8,7 @@ using Xunit;
 
 namespace System.Text.Json
 {
-//#pragma warning disable xUnit1000
     public static partial class WritableJsonApiTests
-//#pragma warning restore xUnit1000
     {
         /// <summary>
         /// Creating simple Json object

--- a/src/System.Text.Json/tests/WritableJsonApiTests.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.cs
@@ -36,7 +36,7 @@ namespace System.Text.Json
 
             Assert.IsType<JsonBoolean>(developer["is developer"]);
             var isDeveloperCasted = developer["is developer"] as JsonBoolean;
-            Assert.Equal(true, isDeveloperCasted.Value);
+            Assert.True(isDeveloperCasted.Value);
 
             Assert.Null(developer["null property"]);
         }
@@ -64,7 +64,7 @@ namespace System.Text.Json
 
             Assert.IsType<JsonBoolean>(developer["is developer"]);
             var isDeveloperCasted = developer["is developer"] as JsonBoolean;
-            Assert.Equal(true, isDeveloperCasted.Value);
+            Assert.True(isDeveloperCasted.Value);
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace System.Text.Json
 
             Assert.IsType<JsonNumber>(circle["radius"]);
             var radius = circle["radius"] as JsonNumber;
-            Assert.Equal(radius, 1);
+            Assert.Equal(1, radius);
 
             Assert.IsType<JsonNumber>(circle["length"]);
             var length = circle["length"] as JsonNumber;

--- a/src/System.Text.Json/tests/WritableJsonApiTests.cs
+++ b/src/System.Text.Json/tests/WritableJsonApiTests.cs
@@ -8,9 +8,9 @@ using Xunit;
 
 namespace System.Text.Json
 {
-#pragma warning disable xUnit1000
-    internal static partial class WritableJsonApiTests
-#pragma warning restore xUnit1000
+//#pragma warning disable xUnit1000
+    public static partial class WritableJsonApiTests
+//#pragma warning restore xUnit1000
     {
         /// <summary>
         /// Creating simple Json object


### PR DESCRIPTION
I implemented `JsonNumber` methods using string to keep the actual value (and added more tests for it). I also added more equals-related methods to JsonNumber, JsonBoolean and JsonString.

cc: @joperezr @bartonjs @ericstj @ahsonkhan @terrajobst